### PR TITLE
feat: add metadata review center and atomic remapping

### DIFF
--- a/Plugins/SecondDimensionWatcherReDive.Inference.AI/Engines/InferenceEngine.cs
+++ b/Plugins/SecondDimensionWatcherReDive.Inference.AI/Engines/InferenceEngine.cs
@@ -49,7 +49,8 @@ public sealed partial class InferenceEngine(
         Output contract — violating this is a fatal error:
         • Exactly one JSON object, nothing else.
         • No ```json fences. No "Here is…" preamble. No explanation after the JSON.
-        • Schema: {"tmdb_id":"str|null","group_name":"str|null","season":int|null,"episode":int|null}
+        • Schema: {"tmdb_id":"str|null","group_name":"str|null","season":int|null,"episode":int|null,"confidence":number}
+        • confidence MUST be between 0 and 1. Use a lower value when the TMDB match, season normalization, episode, or group is uncertain. Use 1 only when every value is strongly supported by the feed and TMDB results.
         """;
 
     private const string FileNameSystemPrompt = """
@@ -98,10 +99,14 @@ public sealed partial class InferenceEngine(
                 LogInferenceNoResult(logger, title);
             return result;
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             LogInferenceFailed(logger, ex, title);
-            return null;
+            throw;
         }
         finally
         {
@@ -269,11 +274,19 @@ public sealed partial class InferenceEngine(
 
         if (json == null) return null;
 
+        var confidence = json["confidence"]?.GetValue<double?>();
+        if (confidence is not null
+            && (double.IsNaN(confidence.Value)
+                || double.IsInfinity(confidence.Value)
+                || confidence is < 0 or > 1))
+            confidence = null;
+
         return new InferenceResult(
             TmdbId: json["tmdb_id"]?.GetValue<string>(),
             GroupName: json["group_name"]?.GetValue<string>(),
             Season: json["season"]?.GetValue<int?>(),
-            Episode: json["episode"]?.GetValue<int?>());
+            Episode: json["episode"]?.GetValue<int?>(),
+            Confidence: confidence);
     }
 
     private static IReadOnlyList<FileNameInferenceResult> ParseFileNameInferenceResults(

--- a/Plugins/SecondDimensionWatcherReDive.Inference.AI/InferenceServiceExtensions.cs
+++ b/Plugins/SecondDimensionWatcherReDive.Inference.AI/InferenceServiceExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using SecondDimensionWatcherReDive.AI;
 using SecondDimensionWatcherReDive.Framework.Inference;
 using SecondDimensionWatcherReDive.Inference.AI.Configuration;
@@ -11,10 +12,27 @@ namespace SecondDimensionWatcherReDive.Inference.AI;
 
 public static class InferenceServiceExtensions
 {
+    public static IServiceCollection AddTmdbMetadata(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var tmdbApiKey = configuration["TmdbApiKey"];
+        var isConfigured = !string.IsNullOrWhiteSpace(tmdbApiKey);
+        services.TryAddSingleton(_ => new TMDbClient(
+            isConfigured ? tmdbApiKey! : "tmdb-api-key-not-configured"));
+        services.TryAddSingleton(serviceProvider => new TmdbTool(
+            serviceProvider.GetRequiredService<TMDbClient>(),
+            serviceProvider.GetRequiredService<Microsoft.Extensions.Logging.ILogger<TmdbTool>>(),
+            isConfigured));
+        return services;
+    }
+
     public static IServiceCollection AddAIInference(
         this IServiceCollection services,
         IConfiguration configuration)
     {
+        services.AddTmdbMetadata(configuration);
+
         // Register AI engine (provider selection handled inside)
         services.AddAIEngine(configuration);
 
@@ -23,9 +41,6 @@ public static class InferenceServiceExtensions
             .BindConfiguration(InferenceOptions.SectionName);
 
         // Register TMDB tool and individual tool classes
-        var tmdbApiKey = configuration["TmdbApiKey"];
-        services.AddSingleton(_ => new TMDbClient(tmdbApiKey ?? string.Empty));
-        services.AddSingleton<TmdbTool>();
         services.AddSingleton<SearchTmdbTool>();
         services.AddSingleton<GetTmdbSeasonsTool>();
         services.AddSingleton<GetTmdbSeasonEpisodesTool>();

--- a/Plugins/SecondDimensionWatcherReDive.Inference.AI/Tools/TmdbTool.cs
+++ b/Plugins/SecondDimensionWatcherReDive.Inference.AI/Tools/TmdbTool.cs
@@ -5,18 +5,38 @@ using TMDbLib.Client;
 
 namespace SecondDimensionWatcherReDive.Inference.AI.Tools;
 
-public partial class TmdbTool(TMDbClient tmdbClient, ILogger<TmdbTool> logger)
+public partial class TmdbTool
 {
+    private readonly bool _isConfigured;
+    private readonly ILogger<TmdbTool> _logger;
+    private readonly TMDbClient _tmdbClient;
+
+    public TmdbTool(TMDbClient tmdbClient, ILogger<TmdbTool> logger)
+        : this(tmdbClient, logger, true)
+    {
+    }
+
+    public TmdbTool(TMDbClient tmdbClient, ILogger<TmdbTool> logger, bool isConfigured)
+    {
+        _tmdbClient = tmdbClient;
+        _logger = logger;
+        _isConfigured = isConfigured;
+    }
+
+    public bool IsConfigured => _isConfigured;
+
     public async Task<string> SearchAsync(string query, CancellationToken cancellationToken)
     {
-        LogSearching(logger, query);
+        if (!_isConfigured) return "[]";
+
+        LogSearching(_logger, query);
         try
         {
-            var tvResults = await tmdbClient.SearchTvShowAsync(query, cancellationToken: cancellationToken);
+            var tvResults = await _tmdbClient.SearchTvShowAsync(query, cancellationToken: cancellationToken);
 
             if (tvResults?.Results is { Count: > 0 })
             {
-                LogFoundTvResults(logger, tvResults.Results.Count, query);
+                LogFoundTvResults(_logger, tvResults.Results.Count, query);
                 var results = tvResults.Results.Take(5).Select(r => new
                 {
                     tmdb_id = r.Id.ToString(),
@@ -29,11 +49,11 @@ public partial class TmdbTool(TMDbClient tmdbClient, ILogger<TmdbTool> logger)
                 return JsonSerializer.Serialize(results);
             }
 
-            var movieResults = await tmdbClient.SearchMovieAsync(query, cancellationToken: cancellationToken);
+            var movieResults = await _tmdbClient.SearchMovieAsync(query, cancellationToken: cancellationToken);
 
             if (movieResults?.Results is { Count: > 0 })
             {
-                LogFoundMovieResults(logger, movieResults.Results.Count, query);
+                LogFoundMovieResults(_logger, movieResults.Results.Count, query);
                 var results = movieResults.Results.Take(5).Select(r => new
                 {
                     tmdb_id = r.Id.ToString(),
@@ -46,25 +66,27 @@ public partial class TmdbTool(TMDbClient tmdbClient, ILogger<TmdbTool> logger)
                 return JsonSerializer.Serialize(results);
             }
 
-            LogNoResultsFound(logger, query);
+            LogNoResultsFound(_logger, query);
             return "[]";
         }
         catch (Exception ex)
         {
-            LogSearchFailed(logger, ex, query);
+            LogSearchFailed(_logger, ex, query);
             return "[]";
         }
     }
 
     public async Task<string> GetSeasonsAsync(int tmdbId, CancellationToken cancellationToken)
     {
-        LogGettingSeasonInfo(logger, tmdbId);
+        if (!_isConfigured) return "{}";
+
+        LogGettingSeasonInfo(_logger, tmdbId);
         try
         {
-            var show = await tmdbClient.GetTvShowAsync(tmdbId, cancellationToken: cancellationToken);
+            var show = await _tmdbClient.GetTvShowAsync(tmdbId, cancellationToken: cancellationToken);
             if (show == null)
             {
-                LogTvShowNotFound(logger, tmdbId);
+                LogTvShowNotFound(_logger, tmdbId);
                 return "{}";
             }
 
@@ -88,25 +110,27 @@ public partial class TmdbTool(TMDbClient tmdbClient, ILogger<TmdbTool> logger)
                 seasons
             };
 
-            LogShowSeasonCount(logger, tmdbId, seasons.Count);
+            LogShowSeasonCount(_logger, tmdbId, seasons.Count);
             return JsonSerializer.Serialize(result);
         }
         catch (Exception ex)
         {
-            LogGetSeasonsFailed(logger, ex, tmdbId);
+            LogGetSeasonsFailed(_logger, ex, tmdbId);
             return "{}";
         }
     }
 
     public async Task<string> GetSeasonEpisodesAsync(int tmdbId, int seasonNumber, CancellationToken cancellationToken)
     {
-        LogGettingSeasonEpisodes(logger, tmdbId, seasonNumber);
+        if (!_isConfigured) return "{}";
+
+        LogGettingSeasonEpisodes(_logger, tmdbId, seasonNumber);
         try
         {
-            var season = await tmdbClient.GetTvSeasonAsync(tmdbId, seasonNumber, cancellationToken: cancellationToken);
+            var season = await _tmdbClient.GetTvSeasonAsync(tmdbId, seasonNumber, cancellationToken: cancellationToken);
             if (season == null)
             {
-                LogSeasonNotFound(logger, tmdbId, seasonNumber);
+                LogSeasonNotFound(_logger, tmdbId, seasonNumber);
                 return "{}";
             }
 
@@ -128,12 +152,12 @@ public partial class TmdbTool(TMDbClient tmdbClient, ILogger<TmdbTool> logger)
                 episodes
             };
 
-            LogSeasonEpisodeCount(logger, tmdbId, seasonNumber, episodes.Count);
+            LogSeasonEpisodeCount(_logger, tmdbId, seasonNumber, episodes.Count);
             return JsonSerializer.Serialize(result);
         }
         catch (Exception ex)
         {
-            LogGetSeasonEpisodesFailed(logger, ex, tmdbId, seasonNumber);
+            LogGetSeasonEpisodesFailed(_logger, ex, tmdbId, seasonNumber);
             return "{}";
         }
     }
@@ -144,11 +168,13 @@ public partial class TmdbTool(TMDbClient tmdbClient, ILogger<TmdbTool> logger)
     /// </summary>
     public async Task<TmdbDetails?> GetLocalizedDetailsAsync(int tmdbId, CancellationToken cancellationToken)
     {
+        if (!_isConfigured) return null;
+
         var language = CultureInfo.CurrentCulture.Name; // e.g. "zh-CN", "en-US", "ja-JP"
-        LogGettingLocalizedDetails(logger, tmdbId, language);
+        LogGettingLocalizedDetails(_logger, tmdbId, language);
         try
         {
-            var show = await tmdbClient.GetTvShowAsync(tmdbId, language: language,
+            var show = await _tmdbClient.GetTvShowAsync(tmdbId, language: language,
                 cancellationToken: cancellationToken);
             if (show == null) return null;
 
@@ -160,7 +186,7 @@ public partial class TmdbTool(TMDbClient tmdbClient, ILogger<TmdbTool> logger)
         }
         catch (Exception ex)
         {
-            LogGetLocalizedDetailsFailed(logger, ex, tmdbId);
+            LogGetLocalizedDetailsFailed(_logger, ex, tmdbId);
             return null;
         }
     }

--- a/SecondDimensionWatcherReDive.Client/mock-server.mjs
+++ b/SecondDimensionWatcherReDive.Client/mock-server.mjs
@@ -1,9 +1,8 @@
 // Mock API server for frontend development/testing.
 // Run with: yarn mock (or: node mock-server.mjs)
 // Then run: yarn start — the Parcel proxy forwards /api/* to this server.
-
+import { randomBytes, randomUUID } from "node:crypto";
 import { createServer } from "node:http";
-import { randomUUID, randomBytes } from "node:crypto";
 
 const PORT = parseInt(process.env.MOCK_PORT ?? "5097", 10);
 
@@ -60,31 +59,244 @@ function hasAuth(req) {
 let registered = false;
 
 const ANIME_TITLES = [
-  { title: "[Mikanani] 葬送的芙莉莲 / Sousou no Frieren - 28 (1080p)", desc: "勇者一行的魔法使芙莉莲的旅途故事", season: 1, episode: 28, animeName: "葬送的芙莉莲", originalName: "Sousou no Frieren", tmdbId: "209867", posterPath: "/dqZENchTd7lp5zht7BdlqM7RBhD.jpg" },
-  { title: "[SubsPlease] 迷宫饭 / Dungeon Meshi - 24 (1080p)", desc: "在地下城中烹饪魔物的冒险者们", season: 1, episode: 24, animeName: "迷宫饭", originalName: "Dungeon Meshi", tmdbId: "220150", posterPath: "/b8dFp1MKnfJCMQvMfnYnBjPuqEu.jpg" },
-  { title: "[Mikanani] 药屋少女的呢喃 / Kusuriya no Hitorigoto - 24 (1080p)", desc: "后宫药师猫猫的推理日常", season: 1, episode: 24, animeName: "药屋少女的呢喃", originalName: "Kusuriya no Hitorigoto", tmdbId: "229598", posterPath: "/hBsMO2fGMRYCFIApI2nkYCApzAb.jpg" },
-  { title: "[ANi] 我心里危险的东西 第二季 - 13 (1080p)", desc: "市川与山田的青春恋爱物语", season: 2, episode: 13, animeName: "我心里危险的东西", originalName: "Boku no Kokoro no Yabai Yatsu", tmdbId: "203737", posterPath: "/qCHIPLBSfUMWS01qnJGnPXlSKGZ.jpg" },
-  { title: "[Mikanani] 物语系列 Off & Monster Season - 12 (1080p)", desc: "阿良良木历的怪异故事继续", season: 1, episode: 12, animeName: "物语系列", originalName: "Monogatari Series", tmdbId: "46195", posterPath: "/oO0eeCAXsQQcq0DjOEJXNKlrBR2.jpg" },
-  { title: "[SubsPlease] 鬼灭之刃 柱训练篇 - 08 (1080p)", desc: "炭治郎与柱们的训练篇章", season: 4, episode: 8, animeName: "鬼灭之刃", originalName: "Kimetsu no Yaiba", tmdbId: "85937", posterPath: "/wrC2TWAOPQMD4bpGjdwH7MjjPT3.jpg" },
-  { title: "[Mikanani] 无职转生 第三季 - 12 (1080p)", desc: "鲁迪乌斯的异世界冒险续篇", season: 3, episode: 12, animeName: "无职转生", originalName: "Mushoku Tensei", tmdbId: "97986", posterPath: "/dBxxtfhC4vYISbxCDMRSpDDiO6B.jpg" },
-  { title: "[ANi] 败犬女主太多了 - 12 (1080p)", desc: "温水和是被选中的那个男人", season: 1, episode: 12, animeName: "败犬女主太多了", originalName: "Make Heroine ga Oosugiru!", tmdbId: "253485", posterPath: "/wZVcuBejljRQJcR3lG6OofJDbeQ.jpg" },
-  { title: "[SubsPlease] 夏日重现 / Summer Time Rendering - 25 (1080p)", desc: "小岛上的时间循环悬疑故事", season: 1, episode: 25, animeName: "夏日重现", originalName: "Summer Time Rendering", tmdbId: "125392", posterPath: "/aURJQ3AyBi1MCPaV1oGNysv5piI.jpg" },
-  { title: "[Mikanani] 孤独摇滚 / Bocchi the Rock! - 12 (1080p)", desc: "社恐少女后藤一里的乐队之路", season: 1, episode: 12, animeName: "孤独摇滚", originalName: "Bocchi the Rock!", tmdbId: "203354", posterPath: "/yPCxMlsEJFsOlDiXUkLlAqL1gp0.jpg" },
-  { title: "[ANi] 间谍过家家 第三季 - 12 (1080p)", desc: "黄昏一家的间谍喜剧日常", season: 3, episode: 12, animeName: "间谍过家家", originalName: "SPY×FAMILY", tmdbId: "110248", posterPath: "/3bWEMlYABPXCNYBZhcjyxLKoRBL.jpg" },
-  { title: "[SubsPlease] 青之箱 / Blue Box - 24 (1080p)", desc: "大喜与千夏的恋爱与羽毛球", season: 1, episode: 24, animeName: "青之箱", originalName: "Ao no Hako", tmdbId: "262596", posterPath: "/j1zidhOBnPpB4axbCSIDQTWoNKN.jpg" },
-  { title: "[Mikanani] Re:从零开始的异世界生活 第三季 - 16 (1080p)", desc: "昴在异世界的又一次轮回", season: 3, episode: 16, animeName: "Re:从零开始的异世界生活", originalName: "Re:Zero", tmdbId: "65006", posterPath: "/4Dub8EWkEJiVkQduXyRuuspbAEh.jpg" },
-  { title: "[ANi] 魔法少女毁灭者 - 12 (1080p)", desc: "以暴力手段对抗魔法少女", season: 1, episode: 12 },
-  { title: "[SubsPlease] 怪兽8号 / Kaiju No. 8 - 12 (1080p)", desc: "日比野卡夫卡的怪兽之力", season: 1, episode: 12, animeName: "怪兽8号", originalName: "Kaiju No. 8", tmdbId: "237091", posterPath: "/9K5DISM3MpCpIYI6VwVoaQOxKlV.jpg" },
-  { title: "[Mikanani] 天国大魔境 / Tengoku Daimakyou - 13 (1080p)", desc: "废墟日本的末日生存之旅", season: 1, episode: 13, animeName: "天国大魔境", originalName: "Tengoku Daimakyou", tmdbId: "198225", posterPath: "/rHzZqeAunqRZnRDnjkKvMN9VXaA.jpg" },
-  { title: "[ANi] 摇曳露营 第三季 - 12 (1080p)", desc: "志摩凛与各务原抚子的户外露营日常", season: 3, episode: 12, animeName: "摇曳露营", originalName: "Yuru Camp", tmdbId: "73042", posterPath: "/kLBltKJYY9kReQIaGwZRmC3rJxo.jpg" },
-  { title: "[SubsPlease] 排球少年 垃圾场决战 (1080p)", desc: "音驹 vs 乌野的巅峰之战", season: 4, episode: null, animeName: "排球少年", originalName: "Haikyuu!!", tmdbId: "60863", posterPath: "/4bHCJxrpNaGNiCJwSzdAlGhkidb.jpg" },
-  { title: "[Mikanani] 地错 第五季 - 12 (1080p)", desc: "贝尔在地下城寻求邂逅", season: 5, episode: 12, animeName: "在地下城寻求邂逅是否搞错了什么", originalName: "DanMachi", tmdbId: "62745", posterPath: "/7HtvMBN0Z8dsnvKDh72iAfyD9XF.jpg" },
-  { title: "[ANi] 樱子小姐的脚下埋着尸体 - 12 (1080p)", desc: "九条樱子的骸骨推理", season: 1, episode: 12 },
-  { title: "[SubsPlease] 异世界自杀小队 - 10 (1080p)", desc: "DC反派们的异世界冒险", season: 1, episode: 10 },
-  { title: "[Mikanani] 葬送的芙莉莲 / Sousou no Frieren - 27 (1080p)", desc: "勇者一行的魔法使芙莉莲的旅途故事", season: 1, episode: 27, animeName: "葬送的芙莉莲", originalName: "Sousou no Frieren", tmdbId: "209867", posterPath: "/dqZENchTd7lp5zht7BdlqM7RBhD.jpg" },
-  { title: "[Mikanani] 葬送的芙莉莲 / Sousou no Frieren - 26 (1080p)", desc: "勇者一行的魔法使芙莉莲的旅途故事", season: 1, episode: 26, animeName: "葬送的芙莉莲", originalName: "Sousou no Frieren", tmdbId: "209867", posterPath: "/dqZENchTd7lp5zht7BdlqM7RBhD.jpg" },
-  { title: "[SubsPlease] 鬼灭之刃 柱训练篇 - 07 (1080p)", desc: "炭治郎与柱们的训练篇章", season: 4, episode: 7, animeName: "鬼灭之刃", originalName: "Kimetsu no Yaiba", tmdbId: "85937", posterPath: "/wrC2TWAOPQMD4bpGjdwH7MjjPT3.jpg" },
-  { title: "[ANi] 间谍过家家 第三季 - 11 (1080p)", desc: "黄昏一家的间谍喜剧日常", season: 3, episode: 11, animeName: "间谍过家家", originalName: "SPY×FAMILY", tmdbId: "110248", posterPath: "/3bWEMlYABPXCNYBZhcjyxLKoRBL.jpg" },
+  {
+    title: "[Mikanani] 葬送的芙莉莲 / Sousou no Frieren - 28 (1080p)",
+    desc: "勇者一行的魔法使芙莉莲的旅途故事",
+    season: 1,
+    episode: 28,
+    animeName: "葬送的芙莉莲",
+    originalName: "Sousou no Frieren",
+    tmdbId: "209867",
+    posterPath: "/dqZENchTd7lp5zht7BdlqM7RBhD.jpg",
+  },
+  {
+    title: "[SubsPlease] 迷宫饭 / Dungeon Meshi - 24 (1080p)",
+    desc: "在地下城中烹饪魔物的冒险者们",
+    season: 1,
+    episode: 24,
+    animeName: "迷宫饭",
+    originalName: "Dungeon Meshi",
+    tmdbId: "220150",
+    posterPath: "/b8dFp1MKnfJCMQvMfnYnBjPuqEu.jpg",
+  },
+  {
+    title: "[Mikanani] 药屋少女的呢喃 / Kusuriya no Hitorigoto - 24 (1080p)",
+    desc: "后宫药师猫猫的推理日常",
+    season: 1,
+    episode: 24,
+    animeName: "药屋少女的呢喃",
+    originalName: "Kusuriya no Hitorigoto",
+    tmdbId: "229598",
+    posterPath: "/hBsMO2fGMRYCFIApI2nkYCApzAb.jpg",
+  },
+  {
+    title: "[ANi] 我心里危险的东西 第二季 - 13 (1080p)",
+    desc: "市川与山田的青春恋爱物语",
+    season: 2,
+    episode: 13,
+    animeName: "我心里危险的东西",
+    originalName: "Boku no Kokoro no Yabai Yatsu",
+    tmdbId: "203737",
+    posterPath: "/qCHIPLBSfUMWS01qnJGnPXlSKGZ.jpg",
+  },
+  {
+    title: "[Mikanani] 物语系列 Off & Monster Season - 12 (1080p)",
+    desc: "阿良良木历的怪异故事继续",
+    season: 1,
+    episode: 12,
+    animeName: "物语系列",
+    originalName: "Monogatari Series",
+    tmdbId: "46195",
+    posterPath: "/oO0eeCAXsQQcq0DjOEJXNKlrBR2.jpg",
+  },
+  {
+    title: "[SubsPlease] 鬼灭之刃 柱训练篇 - 08 (1080p)",
+    desc: "炭治郎与柱们的训练篇章",
+    season: 4,
+    episode: 8,
+    animeName: "鬼灭之刃",
+    originalName: "Kimetsu no Yaiba",
+    tmdbId: "85937",
+    posterPath: "/wrC2TWAOPQMD4bpGjdwH7MjjPT3.jpg",
+  },
+  {
+    title: "[Mikanani] 无职转生 第三季 - 12 (1080p)",
+    desc: "鲁迪乌斯的异世界冒险续篇",
+    season: 3,
+    episode: 12,
+    animeName: "无职转生",
+    originalName: "Mushoku Tensei",
+    tmdbId: "97986",
+    posterPath: "/dBxxtfhC4vYISbxCDMRSpDDiO6B.jpg",
+  },
+  {
+    title: "[ANi] 败犬女主太多了 - 12 (1080p)",
+    desc: "温水和是被选中的那个男人",
+    season: 1,
+    episode: 12,
+    animeName: "败犬女主太多了",
+    originalName: "Make Heroine ga Oosugiru!",
+    tmdbId: "253485",
+    posterPath: "/wZVcuBejljRQJcR3lG6OofJDbeQ.jpg",
+  },
+  {
+    title: "[SubsPlease] 夏日重现 / Summer Time Rendering - 25 (1080p)",
+    desc: "小岛上的时间循环悬疑故事",
+    season: 1,
+    episode: 25,
+    animeName: "夏日重现",
+    originalName: "Summer Time Rendering",
+    tmdbId: "125392",
+    posterPath: "/aURJQ3AyBi1MCPaV1oGNysv5piI.jpg",
+  },
+  {
+    title: "[Mikanani] 孤独摇滚 / Bocchi the Rock! - 12 (1080p)",
+    desc: "社恐少女后藤一里的乐队之路",
+    season: 1,
+    episode: 12,
+    animeName: "孤独摇滚",
+    originalName: "Bocchi the Rock!",
+    tmdbId: "203354",
+    posterPath: "/yPCxMlsEJFsOlDiXUkLlAqL1gp0.jpg",
+  },
+  {
+    title: "[ANi] 间谍过家家 第三季 - 12 (1080p)",
+    desc: "黄昏一家的间谍喜剧日常",
+    season: 3,
+    episode: 12,
+    animeName: "间谍过家家",
+    originalName: "SPY×FAMILY",
+    tmdbId: "110248",
+    posterPath: "/3bWEMlYABPXCNYBZhcjyxLKoRBL.jpg",
+  },
+  {
+    title: "[SubsPlease] 青之箱 / Blue Box - 24 (1080p)",
+    desc: "大喜与千夏的恋爱与羽毛球",
+    season: 1,
+    episode: 24,
+    animeName: "青之箱",
+    originalName: "Ao no Hako",
+    tmdbId: "262596",
+    posterPath: "/j1zidhOBnPpB4axbCSIDQTWoNKN.jpg",
+  },
+  {
+    title: "[Mikanani] Re:从零开始的异世界生活 第三季 - 16 (1080p)",
+    desc: "昴在异世界的又一次轮回",
+    season: 3,
+    episode: 16,
+    animeName: "Re:从零开始的异世界生活",
+    originalName: "Re:Zero",
+    tmdbId: "65006",
+    posterPath: "/4Dub8EWkEJiVkQduXyRuuspbAEh.jpg",
+  },
+  {
+    title: "[ANi] 魔法少女毁灭者 - 12 (1080p)",
+    desc: "以暴力手段对抗魔法少女",
+    season: 1,
+    episode: 12,
+  },
+  {
+    title: "[SubsPlease] 怪兽8号 / Kaiju No. 8 - 12 (1080p)",
+    desc: "日比野卡夫卡的怪兽之力",
+    season: 1,
+    episode: 12,
+    animeName: "怪兽8号",
+    originalName: "Kaiju No. 8",
+    tmdbId: "237091",
+    posterPath: "/9K5DISM3MpCpIYI6VwVoaQOxKlV.jpg",
+  },
+  {
+    title: "[Mikanani] 天国大魔境 / Tengoku Daimakyou - 13 (1080p)",
+    desc: "废墟日本的末日生存之旅",
+    season: 1,
+    episode: 13,
+    animeName: "天国大魔境",
+    originalName: "Tengoku Daimakyou",
+    tmdbId: "198225",
+    posterPath: "/rHzZqeAunqRZnRDnjkKvMN9VXaA.jpg",
+  },
+  {
+    title: "[ANi] 摇曳露营 第三季 - 12 (1080p)",
+    desc: "志摩凛与各务原抚子的户外露营日常",
+    season: 3,
+    episode: 12,
+    animeName: "摇曳露营",
+    originalName: "Yuru Camp",
+    tmdbId: "73042",
+    posterPath: "/kLBltKJYY9kReQIaGwZRmC3rJxo.jpg",
+  },
+  {
+    title: "[SubsPlease] 排球少年 垃圾场决战 (1080p)",
+    desc: "音驹 vs 乌野的巅峰之战",
+    season: 4,
+    episode: null,
+    animeName: "排球少年",
+    originalName: "Haikyuu!!",
+    tmdbId: "60863",
+    posterPath: "/4bHCJxrpNaGNiCJwSzdAlGhkidb.jpg",
+  },
+  {
+    title: "[Mikanani] 地错 第五季 - 12 (1080p)",
+    desc: "贝尔在地下城寻求邂逅",
+    season: 5,
+    episode: 12,
+    animeName: "在地下城寻求邂逅是否搞错了什么",
+    originalName: "DanMachi",
+    tmdbId: "62745",
+    posterPath: "/7HtvMBN0Z8dsnvKDh72iAfyD9XF.jpg",
+  },
+  {
+    title: "[ANi] 樱子小姐的脚下埋着尸体 - 12 (1080p)",
+    desc: "九条樱子的骸骨推理",
+    season: 1,
+    episode: 12,
+  },
+  {
+    title: "[SubsPlease] 异世界自杀小队 - 10 (1080p)",
+    desc: "DC反派们的异世界冒险",
+    season: 1,
+    episode: 10,
+  },
+  {
+    title: "[Mikanani] 葬送的芙莉莲 / Sousou no Frieren - 27 (1080p)",
+    desc: "勇者一行的魔法使芙莉莲的旅途故事",
+    season: 1,
+    episode: 27,
+    animeName: "葬送的芙莉莲",
+    originalName: "Sousou no Frieren",
+    tmdbId: "209867",
+    posterPath: "/dqZENchTd7lp5zht7BdlqM7RBhD.jpg",
+  },
+  {
+    title: "[Mikanani] 葬送的芙莉莲 / Sousou no Frieren - 26 (1080p)",
+    desc: "勇者一行的魔法使芙莉莲的旅途故事",
+    season: 1,
+    episode: 26,
+    animeName: "葬送的芙莉莲",
+    originalName: "Sousou no Frieren",
+    tmdbId: "209867",
+    posterPath: "/dqZENchTd7lp5zht7BdlqM7RBhD.jpg",
+  },
+  {
+    title: "[SubsPlease] 鬼灭之刃 柱训练篇 - 07 (1080p)",
+    desc: "炭治郎与柱们的训练篇章",
+    season: 4,
+    episode: 7,
+    animeName: "鬼灭之刃",
+    originalName: "Kimetsu no Yaiba",
+    tmdbId: "85937",
+    posterPath: "/wrC2TWAOPQMD4bpGjdwH7MjjPT3.jpg",
+  },
+  {
+    title: "[ANi] 间谍过家家 第三季 - 11 (1080p)",
+    desc: "黄昏一家的间谍喜剧日常",
+    season: 3,
+    episode: 11,
+    animeName: "间谍过家家",
+    originalName: "SPY×FAMILY",
+    tmdbId: "110248",
+    posterPath: "/3bWEMlYABPXCNYBZhcjyxLKoRBL.jpg",
+  },
 ];
 
 /** @type {Map<string, object>} */
@@ -148,6 +360,193 @@ function initAnimations() {
 
 initAnimations();
 
+// Metadata review queue. Preview objects are short-lived and bind an edited
+// metadata snapshot to the item's current revision, just like the real API.
+const metadataReviewItems = new Map();
+const metadataReviewPreviews = new Map();
+const metadataReviewOperations = [];
+const metadataCatalog = new Map(
+  ANIME_TITLES.filter((entry) => entry.tmdbId).map((entry) => [
+    entry.tmdbId,
+    {
+      tmdbId: entry.tmdbId,
+      name: entry.animeName,
+      originalName: entry.originalName ?? null,
+      posterPath: entry.posterPath ?? null,
+    },
+  ]),
+);
+
+function mockMappedFiles(animation, index) {
+  if (!animation.isDownloadFinished) return [];
+  const name = animation.animation?.name ?? "unknown";
+  const groupName = animation.group?.name ?? "Unknown";
+  const season = String(animation.season ?? 1).padStart(2, "0");
+  const episode = String(animation.episode ?? 1).padStart(2, "0");
+  const base = `${name} S${season}E${episode}`;
+  const root = `/${name}/${groupName}`;
+  const files = [
+    {
+      fileName: `${base}.mkv`,
+      currentVirtualPath: `${root}/${base}.mkv`,
+    },
+  ];
+  if (index === 0 || index === 2) {
+    files.push({
+      fileName: `${base}.zh.srt`,
+      currentVirtualPath: `${root}/${base}.zh.srt`,
+    });
+  }
+  if (index === 17) {
+    files.push(
+      {
+        fileName: `${base}-02.mkv`,
+        currentVirtualPath: `${root}/${base}-02.mkv`,
+      },
+      {
+        fileName: `${base}-03.mkv`,
+        currentVirtualPath: `${root}/${base}-03.mkv`,
+      },
+    );
+  }
+  return files;
+}
+
+function initMetadataReviewItems() {
+  const queueSeeds = [
+    { index: 0, status: "lowConfidence", confidence: 0.42 },
+    { index: 1, status: "lowConfidence", confidence: 0.56 },
+    { index: 2, status: "pending", confidence: null },
+    { index: 3, status: "lowConfidence", confidence: 0.48 },
+    { index: 4, status: "pending", confidence: null },
+    { index: 5, status: "failed", confidence: null },
+    { index: 6, status: "lowConfidence", confidence: 0.61 },
+    { index: 7, status: "pending", confidence: null },
+    { index: 13, status: "failed", confidence: null },
+    { index: 17, status: "failed", confidence: null },
+    { index: 19, status: "failed", confidence: null },
+    { index: 20, status: "pending", confidence: null },
+  ];
+  const values = [...animations.values()];
+
+  for (const seed of queueSeeds) {
+    const animation = values[seed.index];
+    if (!animation) continue;
+    const forceUnresolved =
+      seed.status === "pending" ||
+      (seed.status === "failed" && animation.animation == null);
+    const files = mockMappedFiles(animation, seed.index);
+    metadataReviewItems.set(animation.id, {
+      id: animation.id,
+      title: animation.title,
+      description: animation.description ?? null,
+      publishTime: animation.publishTime,
+      reviewStatus: seed.status,
+      confidence: seed.confidence,
+      failureReason:
+        seed.status === "failed"
+          ? seed.index === 17
+            ? "AI response did not contain a usable episode number."
+            : "Metadata inference failed after the configured retry limit."
+          : null,
+      aiRetryCount:
+        seed.status === "failed" ? 3 : seed.status === "pending" ? 0 : 1,
+      metadata: {
+        tmdbId: forceUnresolved ? null : (animation.animation?.tmdbId ?? null),
+        name: forceUnresolved ? null : (animation.animation?.name ?? null),
+        originalName: forceUnresolved
+          ? null
+          : (animation.animation?.originalName ?? null),
+        posterPath: forceUnresolved
+          ? null
+          : (animation.animation?.posterPath ?? null),
+        season: forceUnresolved ? null : (animation.season ?? null),
+        episode: forceUnresolved ? null : (animation.episode ?? null),
+        groupName: animation.group?.name ?? null,
+      },
+      isDownloadFinished: animation.isDownloadFinished,
+      mappedFileCount: files.length,
+      revision: 1,
+      currentOperationId: null,
+      files,
+    });
+  }
+}
+
+initMetadataReviewItems();
+
+function publicMetadataReviewItem(item) {
+  const { files: _files, ...publicItem } = item;
+  return publicItem;
+}
+
+function publicMetadataReviewOperation(operation) {
+  return {
+    operationId: operation.operationId,
+    itemId: operation.itemId,
+    title: operation.title,
+    appliedAt: operation.appliedAt,
+    revision: operation.revision,
+    canUndo: operation.canUndo,
+  };
+}
+
+function sanitizePathSegment(value) {
+  return (
+    String(value)
+      .replace(/[\\/:*?"<>|]/g, "_")
+      .trim() || "Unknown"
+  );
+}
+
+function extensionForMockFile(fileName) {
+  const subtitle = fileName.match(/(\.[a-z]{2,3})?\.(srt|ass|vtt)$/i);
+  if (subtitle) return `${subtitle[1] ?? ""}.${subtitle[2]}`;
+  const dot = fileName.lastIndexOf(".");
+  return dot >= 0 ? fileName.slice(dot) : "";
+}
+
+function buildMetadataPathChanges(item, metadata) {
+  if (item.files.length === 0) return [];
+  if (!metadata.name || metadata.season == null) {
+    return item.files.map((file) => ({
+      fileName: file.fileName,
+      currentVirtualPath: file.currentVirtualPath,
+      proposedVirtualPath: null,
+      changeKind: "removed",
+      collisionAdjusted: false,
+    }));
+  }
+
+  const name = sanitizePathSegment(metadata.name);
+  const group = sanitizePathSegment(metadata.groupName ?? "Unknown");
+  const season = String(metadata.season).padStart(2, "0");
+  const episode =
+    metadata.episode == null ? null : String(metadata.episode).padStart(2, "0");
+
+  return item.files.map((file, index) => {
+    const episodeSuffix = episode == null ? "" : `E${episode}`;
+    const extension = extensionForMockFile(file.fileName);
+    const sequenceSuffix =
+      item.files.length > 2 && index > 0
+        ? `-${String(index + 1).padStart(2, "0")}`
+        : "";
+    const baseName = `${name} S${season}${episodeSuffix}${sequenceSuffix}`;
+    const collisionAdjusted =
+      index === 0 && metadata.groupName?.toLowerCase() === "collision";
+    const adjustedBase = collisionAdjusted ? `${baseName} (2)` : baseName;
+    const proposedVirtualPath = `/${name}/${group}/${adjustedBase}${extension}`;
+    return {
+      fileName: file.fileName,
+      currentVirtualPath: file.currentVirtualPath,
+      proposedVirtualPath,
+      changeKind:
+        file.currentVirtualPath === proposedVirtualPath ? "unchanged" : "moved",
+      collisionAdjusted,
+    };
+  });
+}
+
 // Advance download progress every second
 setInterval(() => {
   for (const [id, ds] of downloadState) {
@@ -168,20 +567,45 @@ setInterval(() => {
 // Mock season bangumi data
 const SEASON_BANGUMIS = [
   { mikanId: 3899, title: "尖帽子的魔法工房", dayOfWeek: 1, imageUrl: null },
-  { mikanId: 3904, title: "自称恶役大小姐的婚约者观察记录。", dayOfWeek: 1, imageUrl: null },
-  { mikanId: 3850, title: "吹响吧！上低音号 第三季", dayOfWeek: 2, imageUrl: null },
+  {
+    mikanId: 3904,
+    title: "自称恶役大小姐的婚约者观察记录。",
+    dayOfWeek: 1,
+    imageUrl: null,
+  },
+  {
+    mikanId: 3850,
+    title: "吹响吧！上低音号 第三季",
+    dayOfWeek: 2,
+    imageUrl: null,
+  },
   { mikanId: 3880, title: "怪异与少女与神隐", dayOfWeek: 2, imageUrl: null },
   { mikanId: 3870, title: "暗杀贵族 第二季", dayOfWeek: 3, imageUrl: null },
-  { mikanId: 3815, title: "转生贵族的异世界冒险录 第二季", dayOfWeek: 3, imageUrl: null },
+  {
+    mikanId: 3815,
+    title: "转生贵族的异世界冒险录 第二季",
+    dayOfWeek: 3,
+    imageUrl: null,
+  },
   { mikanId: 3910, title: "无名记忆 第二季", dayOfWeek: 4, imageUrl: null },
   { mikanId: 3920, title: "我的幸福婚约 第三季", dayOfWeek: 4, imageUrl: null },
-  { mikanId: 3860, title: "关于我转生变成史莱姆这档事 第四季", dayOfWeek: 5, imageUrl: null },
+  {
+    mikanId: 3860,
+    title: "关于我转生变成史莱姆这档事 第四季",
+    dayOfWeek: 5,
+    imageUrl: null,
+  },
   { mikanId: 3890, title: "迷宫饭 第二季", dayOfWeek: 5, imageUrl: null },
   { mikanId: 3841, title: "鬼灭之刃 无限城篇", dayOfWeek: 6, imageUrl: null },
   { mikanId: 3900, title: "恋上换装娃娃 第三季", dayOfWeek: 6, imageUrl: null },
   { mikanId: 227, title: "名侦探柯南", dayOfWeek: 0, imageUrl: null },
   { mikanId: 228, title: "航海王", dayOfWeek: 0, imageUrl: null },
-  { mikanId: 3950, title: "剧场版 紫罗兰永恒花园", dayOfWeek: 7, imageUrl: null },
+  {
+    mikanId: 3950,
+    title: "剧场版 紫罗兰永恒花园",
+    dayOfWeek: 7,
+    imageUrl: null,
+  },
 ].map((b) => ({
   ...b,
   id: randomUUID(),
@@ -208,9 +632,24 @@ const MOCK_SUBGROUPS = {
 
 // Feeds
 let feeds = [
-  { id: randomUUID(), url: "https://mikanani.me/RSS/Bangumi?bangumiId=3141", name: "葬送的芙莉莲", createdAt: new Date(Date.now() - 86400_000 * 3).toISOString() },
-  { id: randomUUID(), url: "https://mikanani.me/RSS/Bangumi?bangumiId=3143", name: "迷宫饭", createdAt: new Date(Date.now() - 86400_000 * 2).toISOString() },
-  { id: randomUUID(), url: "https://mikanani.me/RSS/Bangumi?bangumiId=3200", name: "药屋少女的呢喃", createdAt: new Date(Date.now() - 86400_000).toISOString() },
+  {
+    id: randomUUID(),
+    url: "https://mikanani.me/RSS/Bangumi?bangumiId=3141",
+    name: "葬送的芙莉莲",
+    createdAt: new Date(Date.now() - 86400_000 * 3).toISOString(),
+  },
+  {
+    id: randomUUID(),
+    url: "https://mikanani.me/RSS/Bangumi?bangumiId=3143",
+    name: "迷宫饭",
+    createdAt: new Date(Date.now() - 86400_000 * 2).toISOString(),
+  },
+  {
+    id: randomUUID(),
+    url: "https://mikanani.me/RSS/Bangumi?bangumiId=3200",
+    name: "药屋少女的呢喃",
+    createdAt: new Date(Date.now() - 86400_000).toISOString(),
+  },
 ];
 
 // WebDAV access tokens
@@ -250,7 +689,12 @@ const FILE_TREE = {
 
 // Mock VFS tree (mirrors what /api/vfs returns — keyed by absolute virtual path)
 const VFS_NOW = Date.now();
-const vfsDir = (name) => ({ name, isDirectory: true, size: null, lastModifiedUtc: null });
+const vfsDir = (name) => ({
+  name,
+  isDirectory: true,
+  size: null,
+  lastModifiedUtc: null,
+});
 const vfsFile = (name, sizeMb, ageHours) => ({
   name,
   isDirectory: false,
@@ -288,9 +732,7 @@ const VFS_TREE = {
     vfsFile("Trailer.mp4", 32, 240),
     vfsFile("Cover.jpg", 0.4, 240),
   ],
-  "/unknown": [
-    vfsFile("[unsorted] random release.mkv", 700, 6),
-  ],
+  "/unknown": [vfsFile("[unsorted] random release.mkv", 700, 6)],
 };
 
 function vfsResolve(rawPath) {
@@ -322,7 +764,9 @@ function vfsResolve(rawPath) {
 // ---------------------------------------------------------------------------
 
 async function route(method, pathname, searchParams, req, res) {
-  console.log(`${method} ${pathname}${searchParams.toString() ? "?" + searchParams : ""}`);
+  console.log(
+    `${method} ${pathname}${searchParams.toString() ? "?" + searchParams : ""}`,
+  );
 
   // --- CORS preflight ---
   if (method === "OPTIONS") {
@@ -337,16 +781,29 @@ async function route(method, pathname, searchParams, req, res) {
 
   if (method === "POST" && pathname === "/api/auth/register") {
     registered = true;
-    return json(res, { token: fakeToken(), refreshToken: fakeToken(), success: true });
+    return json(res, {
+      token: fakeToken(),
+      refreshToken: fakeToken(),
+      success: true,
+    });
   }
 
   if (method === "POST" && pathname === "/api/auth/login") {
-    if (!registered) return json(res, { token: "", refreshToken: "", success: false });
-    return json(res, { token: fakeToken(), refreshToken: fakeToken(), success: true });
+    if (!registered)
+      return json(res, { token: "", refreshToken: "", success: false });
+    return json(res, {
+      token: fakeToken(),
+      refreshToken: fakeToken(),
+      success: true,
+    });
   }
 
   if (method === "POST" && pathname === "/api/auth/refresh") {
-    return json(res, { token: fakeToken(), refreshToken: fakeToken(), success: true });
+    return json(res, {
+      token: fakeToken(),
+      refreshToken: fakeToken(),
+      success: true,
+    });
   }
 
   if (method === "GET" && pathname === "/api/auth/verify") {
@@ -359,13 +816,284 @@ async function route(method, pathname, searchParams, req, res) {
     return empty(res, 401);
   }
 
+  // --- Metadata review ---
+
+  if (method === "GET" && pathname === "/api/metadata-review") {
+    const status = searchParams.get("status") ?? "pending";
+    if (!["pending", "lowConfidence", "failed"].includes(status)) {
+      return json(res, { error: "Unsupported review status." }, 422);
+    }
+    const skip = Math.max(
+      0,
+      parseInt(searchParams.get("skip") ?? "0", 10) || 0,
+    );
+    const take = Math.min(
+      100,
+      Math.max(1, parseInt(searchParams.get("take") ?? "20", 10) || 20),
+    );
+    const all = [...metadataReviewItems.values()];
+    const filtered = all
+      .filter((item) => item.reviewStatus === status)
+      .sort((a, b) => new Date(b.publishTime) - new Date(a.publishTime));
+    const counts = {
+      pending: all.filter((item) => item.reviewStatus === "pending").length,
+      lowConfidence: all.filter((item) => item.reviewStatus === "lowConfidence")
+        .length,
+      failed: all.filter((item) => item.reviewStatus === "failed").length,
+    };
+    const recentOperations = metadataReviewOperations
+      .slice(0, 10)
+      .map(publicMetadataReviewOperation);
+
+    return json(res, {
+      data: filtered.slice(skip, skip + take).map(publicMetadataReviewItem),
+      totalItems: filtered.length,
+      counts,
+      recentOperations,
+    });
+  }
+
+  // POST /api/metadata-review/:id/preview
+  {
+    const match = pathname.match(/^\/api\/metadata-review\/([^/]+)\/preview$/);
+    if (method === "POST" && match) {
+      const item = metadataReviewItems.get(match[1]);
+      if (!item) return empty(res, 404);
+      const body = await readBody(req);
+      if (body.expectedRevision !== item.revision) {
+        return json(res, { error: "Revision conflict." }, 409);
+      }
+
+      const edited = body.metadata;
+      const validTmdbId =
+        edited &&
+        typeof edited.tmdbId === "string" &&
+        /^\d+$/.test(edited.tmdbId) &&
+        Number(edited.tmdbId) > 0 &&
+        Number(edited.tmdbId) <= 2_147_483_647;
+      const validIndex = (value) =>
+        value === null || (Number.isSafeInteger(value) && value >= 0);
+      const validGroup =
+        edited &&
+        (edited.groupName === null ||
+          (typeof edited.groupName === "string" &&
+            edited.groupName.length <= 200));
+      if (
+        !edited ||
+        !validTmdbId ||
+        edited.season == null ||
+        !validIndex(edited.season) ||
+        !validIndex(edited.episode) ||
+        !validGroup
+      ) {
+        return json(res, { error: "Invalid metadata fields." }, 422);
+      }
+
+      const warnings = [];
+      const catalogEntry = edited.tmdbId
+        ? metadataCatalog.get(edited.tmdbId)
+        : null;
+      let identity;
+      if (catalogEntry) {
+        identity = catalogEntry;
+      } else {
+        identity = {
+          tmdbId: edited.tmdbId,
+          name: `TMDB ${edited.tmdbId}`,
+          originalName: null,
+          posterPath: null,
+        };
+        warnings.push(
+          "The mock catalog does not contain this TMDB ID; a placeholder title will be used.",
+        );
+      }
+
+      const resolvedMetadata = {
+        ...identity,
+        season: edited.season,
+        episode: edited.episode,
+        groupName: edited.groupName?.trim() || null,
+      };
+      if (resolvedMetadata.episode == null) {
+        warnings.push(
+          "No episode was set; downloaded files will use a season-level filename.",
+        );
+      }
+      if (!item.isDownloadFinished) {
+        warnings.push("notDownloaded");
+      }
+
+      const pathChanges = buildMetadataPathChanges(item, resolvedMetadata);
+      const preview = {
+        previewId: randomUUID(),
+        itemId: item.id,
+        baseRevision: item.revision,
+        resolvedMetadata,
+        pathChanges,
+        warnings,
+        canApply: true,
+        expiresAt: new Date(Date.now() + 10 * 60_000).toISOString(),
+      };
+      metadataReviewPreviews.set(preview.previewId, preview);
+      return json(res, {
+        previewId: preview.previewId,
+        baseRevision: preview.baseRevision,
+        resolvedMetadata: preview.resolvedMetadata,
+        pathChanges: preview.pathChanges,
+        warnings: preview.warnings,
+        canApply: preview.canApply,
+        expiresAt: preview.expiresAt,
+      });
+    }
+  }
+
+  // POST /api/metadata-review/:id/apply
+  {
+    const match = pathname.match(/^\/api\/metadata-review\/([^/]+)\/apply$/);
+    if (method === "POST" && match) {
+      const item = metadataReviewItems.get(match[1]);
+      if (!item) return empty(res, 404);
+      const body = await readBody(req);
+      const preview = metadataReviewPreviews.get(body.previewId);
+      if (!preview || preview.itemId !== item.id) {
+        return json(res, { error: "Unknown preview." }, 422);
+      }
+      if (
+        Date.parse(preview.expiresAt) <= Date.now() ||
+        preview.baseRevision !== item.revision
+      ) {
+        metadataReviewPreviews.delete(preview.previewId);
+        return json(res, { error: "Preview is stale." }, 409);
+      }
+      if (!preview.canApply) {
+        return json(res, { error: "Preview cannot be applied." }, 422);
+      }
+
+      if (item.currentOperationId) {
+        const current = metadataReviewOperations.find(
+          (operation) => operation.operationId === item.currentOperationId,
+        );
+        if (current) current.canUndo = false;
+      }
+
+      const previous = {
+        metadata: structuredClone(item.metadata),
+        reviewStatus: item.reviewStatus,
+        confidence: item.confidence,
+        failureReason: item.failureReason,
+        files: structuredClone(item.files),
+        mappedFileCount: item.mappedFileCount,
+        currentOperationId: item.currentOperationId,
+      };
+      const operationId = randomUUID();
+      const appliedAt = new Date().toISOString();
+
+      item.metadata = structuredClone(preview.resolvedMetadata);
+      item.reviewStatus = "reviewed";
+      item.confidence = 1;
+      item.failureReason = null;
+      item.revision += 1;
+      item.currentOperationId = operationId;
+      item.files = preview.pathChanges
+        .filter((change) => change.proposedVirtualPath != null)
+        .map((change) => ({
+          fileName: change.fileName,
+          currentVirtualPath: change.proposedVirtualPath,
+        }));
+      item.mappedFileCount = item.files.length;
+
+      const operation = {
+        operationId,
+        itemId: item.id,
+        title: item.title,
+        appliedAt,
+        revision: item.revision,
+        canUndo: true,
+        previous,
+        pathChanges: structuredClone(preview.pathChanges),
+      };
+      metadataReviewOperations.unshift(operation);
+      metadataReviewPreviews.delete(preview.previewId);
+
+      return json(res, {
+        operationId,
+        revision: item.revision,
+        pathChanges: preview.pathChanges,
+        appliedAt,
+        canUndo: true,
+      });
+    }
+  }
+
+  // POST /api/metadata-review/remaps/:operationId/undo
+  {
+    const match = pathname.match(
+      /^\/api\/metadata-review\/remaps\/([^/]+)\/undo$/,
+    );
+    if (method === "POST" && match) {
+      const operation = metadataReviewOperations.find(
+        (candidate) => candidate.operationId === match[1],
+      );
+      if (!operation) return empty(res, 404);
+      if (!operation.canUndo) {
+        return json(res, { error: "Operation is no longer undoable." }, 422);
+      }
+      const item = metadataReviewItems.get(operation.itemId);
+      if (!item) return empty(res, 404);
+      const body = await readBody(req);
+      if (
+        body.expectedRevision !== item.revision ||
+        item.currentOperationId !== operation.operationId
+      ) {
+        return json(res, { error: "Revision conflict." }, 409);
+      }
+
+      const reverseKind = {
+        added: "removed",
+        removed: "added",
+        moved: "moved",
+        unchanged: "unchanged",
+      };
+      const pathChanges = operation.pathChanges.map((change) => ({
+        fileName: change.fileName,
+        currentVirtualPath: change.proposedVirtualPath,
+        proposedVirtualPath: change.currentVirtualPath,
+        changeKind: reverseKind[change.changeKind],
+        collisionAdjusted: false,
+      }));
+
+      item.metadata = structuredClone(operation.previous.metadata);
+      item.reviewStatus = operation.previous.reviewStatus;
+      item.confidence = operation.previous.confidence;
+      item.failureReason = operation.previous.failureReason;
+      item.files = structuredClone(operation.previous.files);
+      item.mappedFileCount = operation.previous.mappedFileCount;
+      item.revision += 1;
+      item.currentOperationId = operation.previous.currentOperationId;
+      operation.canUndo = false;
+      operation.revision = item.revision;
+      const appliedAt = new Date().toISOString();
+
+      return json(res, {
+        operationId: operation.operationId,
+        revision: item.revision,
+        pathChanges,
+        appliedAt,
+        canUndo: false,
+      });
+    }
+  }
+
   // --- Animation Info ---
 
   if (method === "GET" && pathname === "/api/animationinfo") {
     const skip = parseInt(searchParams.get("skip") ?? "0", 10);
     const take = parseInt(searchParams.get("take") ?? "10", 10);
     const all = [...animations.values()];
-    return json(res, { data: all.slice(skip, skip + take), totalItems: all.length });
+    return json(res, {
+      data: all.slice(skip, skip + take),
+      totalItems: all.length,
+    });
   }
 
   if (method === "GET" && pathname === "/api/animationinfo/grouped") {
@@ -391,13 +1119,21 @@ async function route(method, pathname, searchParams, req, res) {
     }
     const animationsList = [...grouped.values()]
       .map((g) => {
-        g.episodes.sort((a, b) => (a.season ?? 0) - (b.season ?? 0) || (a.episode ?? 0) - (b.episode ?? 0));
+        g.episodes.sort(
+          (a, b) =>
+            (a.season ?? 0) - (b.season ?? 0) ||
+            (a.episode ?? 0) - (b.episode ?? 0),
+        );
         g.episodeCount = g.episodes.length;
         return g;
       })
       .sort((a, b) => {
-        const aMax = Math.max(...a.episodes.map((e) => new Date(e.publishTime).getTime()));
-        const bMax = Math.max(...b.episodes.map((e) => new Date(e.publishTime).getTime()));
+        const aMax = Math.max(
+          ...a.episodes.map((e) => new Date(e.publishTime).getTime()),
+        );
+        const bMax = Math.max(
+          ...b.episodes.map((e) => new Date(e.publishTime).getTime()),
+        );
         return bMax - aMax;
       });
     return json(res, { animations: animationsList, uncategorized });
@@ -409,14 +1145,20 @@ async function route(method, pathname, searchParams, req, res) {
     const list = [...animations.values()].filter(
       (a) => a.isDownloadTracked && !a.isDownloadFinished,
     );
-    return json(res, { data: list.slice(skip, skip + take), totalItems: list.length });
+    return json(res, {
+      data: list.slice(skip, skip + take),
+      totalItems: list.length,
+    });
   }
 
   if (method === "GET" && pathname === "/api/animationinfo/downloaded") {
     const skip = parseInt(searchParams.get("skip") ?? "0", 10);
     const take = parseInt(searchParams.get("take") ?? "10", 10);
     const list = [...animations.values()].filter((a) => a.isDownloadFinished);
-    return json(res, { data: list.slice(skip, skip + take), totalItems: list.length });
+    return json(res, {
+      data: list.slice(skip, skip + take),
+      totalItems: list.length,
+    });
   }
 
   // GET /api/animationinfo/status/:id
@@ -426,10 +1168,12 @@ async function route(method, pathname, searchParams, req, res) {
       const id = m[1];
       const ds = downloadState.get(id);
       if (!ds) return empty(res, 404);
-      const speed = ds.state === "Downloading" ? 2_500_000 + Math.random() * 5_000_000 : 0;
-      const remaining = ds.state === "Downloading" && ds.progress > 0
-        ? ((1 - ds.progress) / 0.02) // ~seconds left
-        : 0;
+      const speed =
+        ds.state === "Downloading" ? 2_500_000 + Math.random() * 5_000_000 : 0;
+      const remaining =
+        ds.state === "Downloading" && ds.progress > 0
+          ? (1 - ds.progress) / 0.02 // ~seconds left
+          : 0;
       return json(res, {
         itemId: id,
         progress: ds.progress,
@@ -450,7 +1194,11 @@ async function route(method, pathname, searchParams, req, res) {
       if (anim.isDownloadTracked) return empty(res, 409);
       anim.isDownloadTracked = true;
       anim.isDownloadFinished = false;
-      downloadState.set(id, { state: "Downloading", progress: 0, startedAt: Date.now() });
+      downloadState.set(id, {
+        state: "Downloading",
+        progress: 0,
+        startedAt: Date.now(),
+      });
       return empty(res, 200);
     }
   }
@@ -532,7 +1280,7 @@ async function route(method, pathname, searchParams, req, res) {
   if (method === "GET" && pathname === "/api/season") {
     const year = searchParams.get("year");
     const season = searchParams.get("season");
-    const seasonLabels = { "春": "春季", "夏": "夏季", "秋": "秋季", "冬": "冬季" };
+    const seasonLabels = { 春: "春季", 夏: "夏季", 秋: "秋季", 冬: "冬季" };
 
     if (year && season) {
       // Return fewer mock entries for non-current seasons
@@ -550,12 +1298,19 @@ async function route(method, pathname, searchParams, req, res) {
       });
     }
 
-    const lastScrapedAt = SEASON_BANGUMIS.length > 0 ? SEASON_BANGUMIS[0].scrapedAt : null;
-    return json(res, { year: null, season: null, lastScrapedAt, bangumis: SEASON_BANGUMIS });
+    const lastScrapedAt =
+      SEASON_BANGUMIS.length > 0 ? SEASON_BANGUMIS[0].scrapedAt : null;
+    return json(res, {
+      year: null,
+      season: null,
+      lastScrapedAt,
+      bangumis: SEASON_BANGUMIS,
+    });
   }
 
   if (method === "POST" && pathname === "/api/season/refresh") {
-    const lastScrapedAt = SEASON_BANGUMIS.length > 0 ? SEASON_BANGUMIS[0].scrapedAt : null;
+    const lastScrapedAt =
+      SEASON_BANGUMIS.length > 0 ? SEASON_BANGUMIS[0].scrapedAt : null;
     return json(res, { lastScrapedAt, bangumis: SEASON_BANGUMIS });
   }
 
@@ -564,10 +1319,12 @@ async function route(method, pathname, searchParams, req, res) {
     const m = pathname.match(/^\/api\/season\/(\d+)\/subgroups$/);
     if (method === "GET" && m) {
       const mikanId = parseInt(m[1], 10);
-      const subgroups = (MOCK_SUBGROUPS[mikanId] ?? [
-        { mikanSubgroupId: 370, name: "LoliHouse" },
-        { mikanSubgroupId: 202, name: "ANi" },
-      ]).map((sg) => ({
+      const subgroups = (
+        MOCK_SUBGROUPS[mikanId] ?? [
+          { mikanSubgroupId: 370, name: "LoliHouse" },
+          { mikanSubgroupId: 202, name: "ANi" },
+        ]
+      ).map((sg) => ({
         ...sg,
         rssUrl: `https://mikanani.me/RSS/Bangumi?bangumiId=${mikanId}&subgroupid=${sg.mikanSubgroupId}`,
       }));
@@ -702,7 +1459,9 @@ async function route(method, pathname, searchParams, req, res) {
   if (method === "GET" && pathname === "/api/file/play") {
     // Return a small placeholder response for mock playback
     res.writeHead(200, { "Content-Type": "text/plain" });
-    return res.end("Mock video playback — this would be a real video file in production.");
+    return res.end(
+      "Mock video playback — this would be a real video file in production.",
+    );
   }
 
   // --- VFS (mirrors /api/vfs on the .NET backend) ---
@@ -741,9 +1500,27 @@ async function route(method, pathname, searchParams, req, res) {
   // --- Tasks ---
 
   const MOCK_TASKS = [
-    { id: "SyncFeed", interval: "00:10:00", isEnabled: true, lastRunAt: new Date(Date.now() - 300_000).toISOString(), isRunning: false },
-    { id: "InferAnimationMetadata", interval: "00:30:00", isEnabled: true, lastRunAt: new Date(Date.now() - 600_000).toISOString(), isRunning: false },
-    { id: "ScrapeSeasonBangumi", interval: "7.00:00:00", isEnabled: true, lastRunAt: new Date(Date.now() - 86400_000).toISOString(), isRunning: false },
+    {
+      id: "SyncFeed",
+      interval: "00:10:00",
+      isEnabled: true,
+      lastRunAt: new Date(Date.now() - 300_000).toISOString(),
+      isRunning: false,
+    },
+    {
+      id: "InferAnimationMetadata",
+      interval: "00:30:00",
+      isEnabled: true,
+      lastRunAt: new Date(Date.now() - 600_000).toISOString(),
+      isRunning: false,
+    },
+    {
+      id: "ScrapeSeasonBangumi",
+      interval: "7.00:00:00",
+      isEnabled: true,
+      lastRunAt: new Date(Date.now() - 86400_000).toISOString(),
+      isRunning: false,
+    },
   ];
 
   if (method === "GET" && pathname === "/api/tasks") {
@@ -755,7 +1532,9 @@ async function route(method, pathname, searchParams, req, res) {
     const m = pathname.match(/^\/api\/tasks\/(.+)\/run$/);
     if (method === "POST" && m) {
       const id = decodeURIComponent(m[1]);
-      const task = MOCK_TASKS.find((t) => t.id.toLowerCase() === id.toLowerCase());
+      const task = MOCK_TASKS.find(
+        (t) => t.id.toLowerCase() === id.toLowerCase(),
+      );
       if (!task) return json(res, { message: `Task '${id}' not found` }, 404);
       task.lastRunAt = new Date().toISOString();
       console.log(`  Mock: task '${id}' executed`);
@@ -764,8 +1543,10 @@ async function route(method, pathname, searchParams, req, res) {
   }
 
   // --- Chat ---
-  const chatConversations = globalThis._chatConversations ?? (globalThis._chatConversations = []);
-  const chatMessages = globalThis._chatMessages ?? (globalThis._chatMessages = new Map());
+  const chatConversations =
+    globalThis._chatConversations ?? (globalThis._chatConversations = []);
+  const chatMessages =
+    globalThis._chatMessages ?? (globalThis._chatMessages = new Map());
 
   // GET /api/chat/status
   if (method === "GET" && pathname === "/api/chat/status") {
@@ -782,7 +1563,12 @@ async function route(method, pathname, searchParams, req, res) {
 
   // GET /api/chat/conversations
   if (method === "GET" && pathname === "/api/chat/conversations") {
-    return json(res, chatConversations.sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt)));
+    return json(
+      res,
+      chatConversations.sort(
+        (a, b) => new Date(b.updatedAt) - new Date(a.updatedAt),
+      ),
+    );
   }
 
   // POST /api/chat/conversations
@@ -859,7 +1645,10 @@ async function route(method, pathname, searchParams, req, res) {
 
       // Auto-title
       if (!conv.title) {
-        conv.title = body.content.length > 30 ? body.content.slice(0, 30) + "..." : body.content;
+        conv.title =
+          body.content.length > 30
+            ? body.content.slice(0, 30) + "..."
+            : body.content;
       }
       conv.updatedAt = new Date().toISOString();
 
@@ -887,11 +1676,13 @@ async function route(method, pathname, searchParams, req, res) {
         "```\n";
 
       const toolArgs = JSON.stringify({ query: body.content });
-      const toolResult = JSON.stringify({ results: [
-        { id: 1, name: "进击的巨人 最终季 完结篇", tmdb_id: 94605 },
-        { id: 2, name: "葬送的芙莉莲", tmdb_id: 209867 },
-        { id: 3, name: "药屋少女的呢喃", tmdb_id: 225239 },
-      ]});
+      const toolResult = JSON.stringify({
+        results: [
+          { id: 1, name: "进击的巨人 最终季 完结篇", tmdb_id: 94605 },
+          { id: 2, name: "葬送的芙莉莲", tmdb_id: 209867 },
+          { id: 3, name: "药屋少女的呢喃", tmdb_id: 225239 },
+        ],
+      });
 
       const steps = [];
 
@@ -917,7 +1708,10 @@ async function route(method, pathname, searchParams, req, res) {
       for (let i = 0; i < argChars.length; i += 5) {
         steps.push({
           event: "tool_call_delta",
-          data: { id: toolCallId, arguments_delta: argChars.slice(i, i + 5).join("") },
+          data: {
+            id: toolCallId,
+            arguments_delta: argChars.slice(i, i + 5).join(""),
+          },
           delay: 30,
         });
       }
@@ -925,7 +1719,11 @@ async function route(method, pathname, searchParams, req, res) {
       // Tool result (after a brief pause)
       steps.push({
         event: "tool_result",
-        data: { tool_call_id: toolCallId, name: "search_tmdb", result: toolResult },
+        data: {
+          tool_call_id: toolCallId,
+          name: "search_tmdb",
+          result: toolResult,
+        },
         delay: 300,
       });
 
@@ -943,7 +1741,9 @@ async function route(method, pathname, searchParams, req, res) {
       let stepIdx = 0;
       function sendNextStep() {
         if (stepIdx >= steps.length) {
-          res.write(`event: finished\ndata: ${JSON.stringify({ stop_reason: "end_turn" })}\n\n`);
+          res.write(
+            `event: finished\ndata: ${JSON.stringify({ stop_reason: "end_turn" })}\n\n`,
+          );
 
           // Save assistant message with tool calls
           const fullText = preToolText + postToolText;
@@ -951,7 +1751,9 @@ async function route(method, pathname, searchParams, req, res) {
             id: randomUUID(),
             role: "assistant",
             content: fullText,
-            toolCallsJson: JSON.stringify([{ id: toolCallId, name: "search_tmdb", arguments: toolArgs }]),
+            toolCallsJson: JSON.stringify([
+              { id: toolCallId, name: "search_tmdb", arguments: toolArgs },
+            ]),
             toolCallId: null,
             toolName: null,
             order: msgs.length,
@@ -974,7 +1776,9 @@ async function route(method, pathname, searchParams, req, res) {
         }
 
         const step = steps[stepIdx++];
-        res.write(`event: ${step.event}\ndata: ${JSON.stringify(step.data)}\n\n`);
+        res.write(
+          `event: ${step.event}\ndata: ${JSON.stringify(step.data)}\n\n`,
+        );
         setTimeout(sendNextStep, step.delay);
       }
 
@@ -993,7 +1797,13 @@ async function route(method, pathname, searchParams, req, res) {
 
 const server = createServer((req, res) => {
   const url = new URL(req.url, `http://localhost:${PORT}`);
-  const result = route(req.method, url.pathname.toLowerCase(), url.searchParams, req, res);
+  const result = route(
+    req.method,
+    url.pathname.toLowerCase(),
+    url.searchParams,
+    req,
+    res,
+  );
   // Handle async routes (readBody returns a Promise)
   if (result instanceof Promise) {
     result.catch((err) => {
@@ -1005,8 +1815,12 @@ const server = createServer((req, res) => {
 
 server.listen(PORT, () => {
   console.log(`Mock API server running on http://localhost:${PORT}`);
-  console.log(`  ${animations.size} anime entries (3 finished, 2 downloading, 1 paused, rest untracked)`);
+  console.log(
+    `  ${animations.size} anime entries (3 finished, 2 downloading, 1 paused, rest untracked)`,
+  );
   console.log(`  ${feeds.length} RSS feeds`);
   console.log(`  Auth: any password works (register first on first visit)`);
-  console.log(`\nRun "yarn start" in another terminal to start the frontend dev server.`);
+  console.log(
+    `\nRun "yarn start" in another terminal to start the frontend dev server.`,
+  );
 });

--- a/SecondDimensionWatcherReDive.Client/src/Main.tsx
+++ b/SecondDimensionWatcherReDive.Client/src/Main.tsx
@@ -11,7 +11,8 @@ import { ErrorPage } from "./pages/ErrorPage";
 import { FeedsPage } from "./pages/FeedsPage";
 import { FilesPage } from "./pages/FilesPage";
 import { LoginPage } from "./pages/LoginPage";
-import { MainPage, EpisodeListPage } from "./pages/MainPage";
+import { EpisodeListPage, MainPage } from "./pages/MainPage";
+import { MetadataReviewPage } from "./pages/MetadataReviewPage";
 import { PlayerPage } from "./pages/PlayerPage";
 import { SettingsPage } from "./pages/SettingsPage";
 import { TasksPage } from "./pages/TasksPage";
@@ -19,62 +20,119 @@ import { TasksPage } from "./pages/TasksPage";
 const router = createBrowserRouter([
   {
     path: "/",
-    element: <ProtectedRoute><MainPage /></ProtectedRoute>,
+    element: (
+      <ProtectedRoute>
+        <MainPage />
+      </ProtectedRoute>
+    ),
     errorElement: <ErrorPage />,
   },
   {
     path: "/main",
-    element: <ProtectedRoute><MainPage /></ProtectedRoute>,
+    element: (
+      <ProtectedRoute>
+        <MainPage />
+      </ProtectedRoute>
+    ),
     errorElement: <ErrorPage />,
   },
   {
     path: "/anime/:tmdbId",
-    element: <ProtectedRoute><EpisodeListPage /></ProtectedRoute>,
+    element: (
+      <ProtectedRoute>
+        <EpisodeListPage />
+      </ProtectedRoute>
+    ),
     errorElement: <ErrorPage />,
   },
   {
     path: "/downloading",
-    element: <ProtectedRoute><DownloadingPage /></ProtectedRoute>,
+    element: (
+      <ProtectedRoute>
+        <DownloadingPage />
+      </ProtectedRoute>
+    ),
     errorElement: <ErrorPage />,
   },
   {
     path: "/downloaded",
-    element: <ProtectedRoute><DownloadedPage /></ProtectedRoute>,
+    element: (
+      <ProtectedRoute>
+        <DownloadedPage />
+      </ProtectedRoute>
+    ),
     errorElement: <ErrorPage />,
   },
   {
     path: "/files",
-    element: <ProtectedRoute><FilesPage /></ProtectedRoute>,
+    element: (
+      <ProtectedRoute>
+        <FilesPage />
+      </ProtectedRoute>
+    ),
     errorElement: <ErrorPage />,
   },
   {
     path: "/play/:animationId",
-    element: <ProtectedRoute><PlayerPage /></ProtectedRoute>,
+    element: (
+      <ProtectedRoute>
+        <PlayerPage />
+      </ProtectedRoute>
+    ),
     errorElement: <ErrorPage />,
   },
   {
     path: "/feeds",
-    element: <ProtectedRoute><FeedsPage /></ProtectedRoute>,
+    element: (
+      <ProtectedRoute>
+        <FeedsPage />
+      </ProtectedRoute>
+    ),
     errorElement: <ErrorPage />,
   },
   {
     path: "/tasks",
-    element: <ProtectedRoute><TasksPage /></ProtectedRoute>,
+    element: (
+      <ProtectedRoute>
+        <TasksPage />
+      </ProtectedRoute>
+    ),
+    errorElement: <ErrorPage />,
+  },
+  {
+    path: "/metadata-review",
+    element: (
+      <ProtectedRoute>
+        <MetadataReviewPage />
+      </ProtectedRoute>
+    ),
     errorElement: <ErrorPage />,
   },
   {
     path: "/chat",
-    element: <ProtectedRoute><ChatPage /></ProtectedRoute>,
+    element: (
+      <ProtectedRoute>
+        <ChatPage />
+      </ProtectedRoute>
+    ),
     errorElement: <ErrorPage />,
   },
   {
     path: "/chat/:conversationId",
-    element: <ProtectedRoute><ChatPage /></ProtectedRoute>,
+    element: (
+      <ProtectedRoute>
+        <ChatPage />
+      </ProtectedRoute>
+    ),
     errorElement: <ErrorPage />,
   },
   {
     path: "/settings",
-    element: <ProtectedRoute><SettingsPage /></ProtectedRoute>,
+    element: (
+      <ProtectedRoute>
+        <SettingsPage />
+      </ProtectedRoute>
+    ),
     errorElement: <ErrorPage />,
   },
   {

--- a/SecondDimensionWatcherReDive.Client/src/components/AppHeader.tsx
+++ b/SecondDimensionWatcherReDive.Client/src/components/AppHeader.tsx
@@ -1,8 +1,13 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { useLocation, useNavigate } from "react-router";
+
 import {
   Check,
   Clapperboard,
   Cog,
   Download,
+  FileSearch,
   FolderOpen,
   Home,
   LayoutGrid,
@@ -12,15 +17,12 @@ import {
   Settings,
   User,
 } from "lucide-react";
-import React from "react";
-import { useTranslation } from "react-i18next";
-import { useNavigate, useLocation } from "react-router";
 
 import { useLoginStatus } from "../auth/hooks";
 import i18n, {
+  type SupportedLanguage,
   languageLabels,
   supportedLanguages,
-  type SupportedLanguage,
 } from "../i18n";
 import { cn } from "../lib/cn";
 import {
@@ -39,11 +41,20 @@ interface NavItem {
 
 const useNavItems = (): NavItem[] => [
   { icon: <Home size={16} />, labelKey: "nav.home", path: "/" },
-  { icon: <Download size={16} />, labelKey: "nav.downloading", path: "/downloading" },
+  {
+    icon: <Download size={16} />,
+    labelKey: "nav.downloading",
+    path: "/downloading",
+  },
   { icon: <List size={16} />, labelKey: "nav.downloaded", path: "/downloaded" },
   { icon: <FolderOpen size={16} />, labelKey: "nav.files", path: "/files" },
   { icon: <LayoutGrid size={16} />, labelKey: "nav.feeds", path: "/feeds" },
   { icon: <Settings size={16} />, labelKey: "nav.tasks", path: "/tasks" },
+  {
+    icon: <FileSearch size={16} />,
+    labelKey: "nav.metadataReview",
+    path: "/metadata-review",
+  },
   { icon: <MessageSquare size={16} />, labelKey: "nav.chat", path: "/chat" },
   { icon: <Cog size={16} />, labelKey: "nav.settings", path: "/settings" },
 ];
@@ -89,13 +100,17 @@ const MobileNavMenu: React.FC = () => {
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className="lg:hidden inline-flex items-center justify-center rounded-md p-1.5 text-muted hover:text-foreground hover:bg-canvas transition-colors"
+          className="xl:hidden inline-flex items-center justify-center rounded-md p-1.5 text-muted hover:text-foreground hover:bg-canvas transition-colors"
           aria-label={t("nav.menu")}
         >
           <Menu size={18} />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" sideOffset={8} className="min-w-[12rem]">
+      <DropdownMenuContent
+        align="start"
+        sideOffset={8}
+        className="min-w-[12rem]"
+      >
         {items.map((item) => {
           const isActive = isPathActive(location.pathname, item.path);
           return (
@@ -188,7 +203,7 @@ export const AppHeader: React.FC = () => {
   return (
     <header className="sticky top-0 z-30 border-b border-border bg-surface/95 backdrop-blur">
       <nav className="flex h-14 items-center justify-between gap-2 px-4 sm:px-6">
-        <div className="flex min-w-0 items-center gap-2 lg:gap-6">
+        <div className="flex min-w-0 items-center gap-2 xl:gap-4">
           <MobileNavMenu />
           <a
             className="flex min-w-0 items-center gap-2 font-serif text-lg font-medium text-foreground cursor-pointer"
@@ -197,7 +212,7 @@ export const AppHeader: React.FC = () => {
             <Clapperboard size={20} className="shrink-0" />
             <span className="truncate">{t("appName")}</span>
           </a>
-          <div className="hidden lg:flex items-center gap-1">
+          <div className="hidden xl:flex items-center gap-0.5">
             {items.map((item) => (
               <NavLink
                 key={item.path}

--- a/SecondDimensionWatcherReDive.Client/src/components/MetadataReviewSheet.tsx
+++ b/SecondDimensionWatcherReDive.Client/src/components/MetadataReviewSheet.tsx
@@ -1,0 +1,512 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  AlertCircle,
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  FileText,
+} from "lucide-react";
+
+import {
+  applyMetadataReview,
+  metadataReviewErrorStatus,
+  previewMetadataReview,
+} from "../metadataReview/api";
+import {
+  EditableMetadata,
+  MetadataPathChange,
+  MetadataRemapResult,
+  MetadataReviewItem,
+  MetadataReviewPreview,
+} from "../metadataReview/types";
+import { Button } from "./ui/Button";
+import { FormRow } from "./ui/FormRow";
+import { Input } from "./ui/Input";
+import {
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "./ui/Sheet";
+import { Spinner } from "./ui/Spinner";
+
+interface MetadataReviewSheetProps {
+  item: MetadataReviewItem | null;
+  onOpenChange: (open: boolean) => void;
+  onApplied: (result: MetadataRemapResult) => void | Promise<void>;
+}
+
+interface EditorFormValues {
+  tmdbId: string;
+  season: string;
+  episode: string;
+  groupName: string;
+}
+
+type EditorField = keyof EditorFormValues;
+type FieldErrors = Partial<Record<EditorField, string>>;
+
+const emptyForm: EditorFormValues = {
+  tmdbId: "",
+  season: "",
+  episode: "",
+  groupName: "",
+};
+
+function formFromItem(item: MetadataReviewItem): EditorFormValues {
+  return {
+    tmdbId: item.metadata.tmdbId ?? "",
+    season: item.metadata.season == null ? "" : String(item.metadata.season),
+    episode: item.metadata.episode == null ? "" : String(item.metadata.episode),
+    groupName: item.metadata.groupName ?? "",
+  };
+}
+
+function apiErrorKey(error: unknown): string {
+  const status = metadataReviewErrorStatus(error);
+  if (status === 409) return "editor.errors.conflict";
+  if (status === 422) return "editor.errors.validation";
+  return "editor.errors.requestFailed";
+}
+
+interface PathDiffProps {
+  changes: MetadataPathChange[];
+}
+
+const PathDiff: React.FC<PathDiffProps> = ({ changes }) => {
+  const { t } = useTranslation("metadataReview");
+
+  if (changes.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border px-4 py-5 text-center text-sm text-muted">
+        {t("preview.noPathChanges")}
+      </div>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-border-light overflow-hidden rounded-lg border border-border bg-canvas/50">
+      {changes.map((change, index) => (
+        <li key={`${change.fileName}-${index}`} className="p-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span className="min-w-0 truncate text-sm font-medium text-foreground">
+              {change.fileName}
+            </span>
+            <span className="rounded-full bg-surface px-2 py-0.5 text-xs text-muted shadow-ring">
+              {t(`preview.changeKinds.${change.changeKind}`)}
+            </span>
+          </div>
+          <div className="mt-2 grid gap-1 font-mono text-xs leading-relaxed sm:grid-cols-[1fr_auto_1fr] sm:items-center">
+            <span className="break-all text-muted">
+              {change.currentVirtualPath ?? t("preview.noPath")}
+            </span>
+            <ArrowRight size={14} className="hidden text-subtle sm:block" />
+            <span className="break-all text-foreground">
+              {change.proposedVirtualPath ?? t("preview.noPath")}
+            </span>
+          </div>
+          {change.collisionAdjusted ? (
+            <p className="mt-2 text-xs text-warning">
+              {t("preview.collisionAdjusted")}
+            </p>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+interface PreviewPanelProps {
+  preview: MetadataReviewPreview;
+  applying: boolean;
+  onApply: () => void;
+}
+
+const PreviewPanel: React.FC<PreviewPanelProps> = ({
+  preview,
+  applying,
+  onApply,
+}) => {
+  const { t } = useTranslation("metadataReview");
+  const metadata = preview.resolvedMetadata;
+  const warningLabel = (warning: string): string => {
+    if (warning === "notDownloaded") {
+      return t("preview.warningCodes.notDownloaded");
+    }
+    if (warning === "unresolvedFiles") {
+      return t("preview.warningCodes.unresolvedFiles");
+    }
+    if (warning === "collisionAdjusted") {
+      return t("preview.collisionAdjusted");
+    }
+    return warning;
+  };
+
+  return (
+    <section className="mt-6 border-t border-border pt-5">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h3 className="font-serif text-base font-medium text-foreground">
+            {t("preview.title")}
+          </h3>
+          <p className="mt-1 text-xs text-subtle">
+            {t("preview.revisionAndExpiry", {
+              revision: preview.baseRevision,
+              expiresAt: new Date(preview.expiresAt).toLocaleTimeString(),
+            })}
+          </p>
+        </div>
+        {preview.canApply ? (
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-success/10 px-2.5 py-1 text-xs font-medium text-success">
+            <CheckCircle2 size={13} />
+            {t("preview.ready")}
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-error/10 px-2.5 py-1 text-xs font-medium text-error">
+            <AlertCircle size={13} />
+            {t("preview.blocked")}
+          </span>
+        )}
+      </div>
+
+      <div className="mt-4 rounded-lg border border-border bg-canvas/50 p-4">
+        <h4 className="text-xs font-medium uppercase tracking-wide text-subtle">
+          {t("preview.resolvedMetadata")}
+        </h4>
+        <dl className="mt-3 grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+          <div className="col-span-2">
+            <dt className="text-xs text-subtle">{t("fields.name")}</dt>
+            <dd className="mt-0.5 text-foreground">
+              {metadata.name ?? t("values.notResolved")}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-subtle">{t("fields.tmdbId")}</dt>
+            <dd className="mt-0.5 text-foreground">
+              {metadata.tmdbId ?? t("values.unset")}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-subtle">{t("fields.groupName")}</dt>
+            <dd className="mt-0.5 text-foreground">
+              {metadata.groupName ?? t("values.unset")}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-subtle">{t("fields.season")}</dt>
+            <dd className="mt-0.5 text-foreground">
+              {metadata.season ?? t("values.unset")}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs text-subtle">{t("fields.episode")}</dt>
+            <dd className="mt-0.5 text-foreground">
+              {metadata.episode ?? t("values.unset")}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      {preview.warnings.length > 0 ? (
+        <div className="mt-4 rounded-lg border border-warning/30 bg-warning/10 p-3 text-sm text-foreground">
+          <div className="flex items-center gap-2 font-medium text-warning">
+            <AlertTriangle size={15} />
+            {t("preview.warnings")}
+          </div>
+          <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-muted">
+            {preview.warnings.map((warning, index) => (
+              <li key={`${warning}-${index}`}>{warningLabel(warning)}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <h4 className="mb-2 mt-5 text-sm font-medium text-foreground">
+        {t("preview.pathChanges", { count: preview.pathChanges.length })}
+      </h4>
+      <PathDiff changes={preview.pathChanges} />
+
+      <div className="mt-5 flex justify-end">
+        <Button onClick={onApply} disabled={!preview.canApply || applying}>
+          {applying ? <Spinner size={16} /> : <CheckCircle2 size={16} />}
+          {applying ? t("editor.applying") : t("editor.apply")}
+        </Button>
+      </div>
+    </section>
+  );
+};
+
+export const MetadataReviewSheet: React.FC<MetadataReviewSheetProps> = ({
+  item,
+  onOpenChange,
+  onApplied,
+}) => {
+  const { t } = useTranslation("metadataReview");
+  const [form, setForm] = React.useState<EditorFormValues>(emptyForm);
+  const [fieldErrors, setFieldErrors] = React.useState<FieldErrors>({});
+  const [preview, setPreview] = React.useState<MetadataReviewPreview | null>(
+    null,
+  );
+  const [requestError, setRequestError] = React.useState<string | null>(null);
+  const [previewing, setPreviewing] = React.useState(false);
+  const [applying, setApplying] = React.useState(false);
+  const formVersion = React.useRef(0);
+
+  React.useEffect(() => {
+    formVersion.current += 1;
+    if (item) setForm(formFromItem(item));
+    else setForm(emptyForm);
+    setFieldErrors({});
+    setPreview(null);
+    setRequestError(null);
+    setPreviewing(false);
+    setApplying(false);
+  }, [item?.id]);
+
+  const updateField = React.useCallback((field: EditorField, value: string) => {
+    formVersion.current += 1;
+    setForm((current) => ({ ...current, [field]: value }));
+    setFieldErrors((current) => ({ ...current, [field]: undefined }));
+    setPreview(null);
+    setRequestError(null);
+  }, []);
+
+  const validate = React.useCallback((): EditableMetadata | null => {
+    const errors: FieldErrors = {};
+    const tmdbId = form.tmdbId.trim();
+
+    const parsedTmdbId = Number(tmdbId);
+    if (
+      !/^\d+$/.test(tmdbId) ||
+      !Number.isSafeInteger(parsedTmdbId) ||
+      parsedTmdbId <= 0 ||
+      parsedTmdbId > 2_147_483_647
+    ) {
+      errors.tmdbId = t("editor.validation.tmdbId");
+    }
+
+    const parseIndex = (
+      field: "season" | "episode",
+      required: boolean,
+    ): number | null => {
+      const raw = form[field].trim();
+      if (!raw) {
+        if (required) errors[field] = t("editor.validation.seasonRequired");
+        return null;
+      }
+      if (!/^\d+$/.test(raw) || !Number.isSafeInteger(Number(raw))) {
+        errors[field] = t("editor.validation.nonNegativeInteger");
+        return null;
+      }
+      return Number(raw);
+    };
+
+    const season = parseIndex("season", true);
+    const episode = parseIndex("episode", false);
+    const groupName = form.groupName.trim();
+    if (groupName.length > 200) {
+      errors.groupName = t("editor.validation.groupNameLength");
+    }
+
+    setFieldErrors(errors);
+    if (Object.keys(errors).length > 0) return null;
+
+    return {
+      tmdbId: tmdbId || null,
+      season,
+      episode,
+      groupName: groupName || null,
+    };
+  }, [form, t]);
+
+  const requestPreview = React.useCallback(async () => {
+    if (!item) return;
+    const metadata = validate();
+    if (!metadata) return;
+
+    const version = formVersion.current;
+    setPreviewing(true);
+    setRequestError(null);
+    setPreview(null);
+    try {
+      const nextPreview = await previewMetadataReview(
+        item.id,
+        item.revision,
+        metadata,
+      );
+      if (formVersion.current === version) setPreview(nextPreview);
+    } catch (error) {
+      if (formVersion.current === version) {
+        setRequestError(t(apiErrorKey(error)));
+      }
+    } finally {
+      setPreviewing(false);
+    }
+  }, [item, t, validate]);
+
+  const applyPreview = React.useCallback(async () => {
+    if (!item || !preview) return;
+    setApplying(true);
+    setRequestError(null);
+    try {
+      const result = await applyMetadataReview(item.id, preview.previewId);
+      await onApplied(result);
+    } catch (error) {
+      setRequestError(t(apiErrorKey(error)));
+    } finally {
+      setApplying(false);
+    }
+  }, [item, onApplied, preview, t]);
+
+  return (
+    <Sheet open={item != null} onOpenChange={onOpenChange}>
+      <SheetContent className="max-w-2xl">
+        <SheetHeader className="pr-14">
+          <SheetTitle>{t("editor.title")}</SheetTitle>
+          {item ? (
+            <p
+              className="mt-1 line-clamp-2 text-sm text-muted"
+              title={item.title}
+            >
+              {item.title}
+            </p>
+          ) : null}
+        </SheetHeader>
+
+        <SheetBody>
+          {item ? (
+            <>
+              <div className="rounded-lg border border-border-light bg-canvas/60 p-4">
+                <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                  <FileText size={15} className="text-muted" />
+                  {t("editor.currentMetadata")}
+                </div>
+                <p className="mt-2 text-sm text-muted">
+                  {item.metadata.name ?? t("values.notResolved")}
+                  <span className="mx-2 text-border">/</span>
+                  {t("editor.currentRevision", { revision: item.revision })}
+                </p>
+              </div>
+
+              <div className="mt-5 space-y-4">
+                <FormRow
+                  label={t("fields.tmdbId")}
+                  isInvalid={!!fieldErrors.tmdbId}
+                  error={fieldErrors.tmdbId ? [fieldErrors.tmdbId] : undefined}
+                >
+                  <Input
+                    value={form.tmdbId}
+                    onChange={(event) =>
+                      updateField("tmdbId", event.target.value)
+                    }
+                    inputMode="numeric"
+                    placeholder={t("editor.placeholders.tmdbId")}
+                    aria-label={t("fields.tmdbId")}
+                    isInvalid={!!fieldErrors.tmdbId}
+                  />
+                </FormRow>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <FormRow
+                    label={t("fields.season")}
+                    isInvalid={!!fieldErrors.season}
+                    error={
+                      fieldErrors.season ? [fieldErrors.season] : undefined
+                    }
+                  >
+                    <Input
+                      value={form.season}
+                      onChange={(event) =>
+                        updateField("season", event.target.value)
+                      }
+                      inputMode="numeric"
+                      placeholder={t("editor.placeholders.season")}
+                      aria-label={t("fields.season")}
+                      isInvalid={!!fieldErrors.season}
+                    />
+                  </FormRow>
+                  <FormRow
+                    label={t("fields.episode")}
+                    isInvalid={!!fieldErrors.episode}
+                    error={
+                      fieldErrors.episode ? [fieldErrors.episode] : undefined
+                    }
+                  >
+                    <Input
+                      value={form.episode}
+                      onChange={(event) =>
+                        updateField("episode", event.target.value)
+                      }
+                      inputMode="numeric"
+                      placeholder={t("editor.placeholders.episode")}
+                      aria-label={t("fields.episode")}
+                      isInvalid={!!fieldErrors.episode}
+                    />
+                  </FormRow>
+                </div>
+
+                <FormRow
+                  label={t("fields.groupName")}
+                  isInvalid={!!fieldErrors.groupName}
+                  error={
+                    fieldErrors.groupName ? [fieldErrors.groupName] : undefined
+                  }
+                >
+                  <Input
+                    value={form.groupName}
+                    onChange={(event) =>
+                      updateField("groupName", event.target.value)
+                    }
+                    placeholder={t("editor.placeholders.groupName")}
+                    aria-label={t("fields.groupName")}
+                    isInvalid={!!fieldErrors.groupName}
+                  />
+                </FormRow>
+
+                <p className="text-xs leading-body text-subtle">
+                  {t("editor.unsetHint")}
+                </p>
+              </div>
+
+              {requestError ? (
+                <div
+                  role="alert"
+                  className="mt-4 flex items-start gap-2 rounded-lg border border-error/30 bg-error/10 p-3 text-sm text-error"
+                >
+                  <AlertCircle size={16} className="mt-0.5 shrink-0" />
+                  <span>{requestError}</span>
+                </div>
+              ) : null}
+
+              <div className="mt-5 flex justify-end">
+                <Button
+                  variant="outline"
+                  onClick={requestPreview}
+                  disabled={previewing || applying}
+                >
+                  {previewing ? <Spinner size={16} /> : <FileText size={16} />}
+                  {previewing
+                    ? t("editor.previewing")
+                    : preview
+                      ? t("editor.refreshPreview")
+                      : t("editor.preview")}
+                </Button>
+              </div>
+
+              {preview ? (
+                <PreviewPanel
+                  preview={preview}
+                  applying={applying}
+                  onApply={applyPreview}
+                />
+              ) : null}
+            </>
+          ) : null}
+        </SheetBody>
+      </SheetContent>
+    </Sheet>
+  );
+};

--- a/SecondDimensionWatcherReDive.Client/src/i18n/locales/en/common.json
+++ b/SecondDimensionWatcherReDive.Client/src/i18n/locales/en/common.json
@@ -7,6 +7,7 @@
     "files": "Files",
     "feeds": "Feeds",
     "tasks": "Tasks",
+    "metadataReview": "Metadata review",
     "chat": "AI Chat",
     "settings": "Settings",
     "menu": "Open menu"

--- a/SecondDimensionWatcherReDive.Client/src/i18n/locales/en/metadataReview.json
+++ b/SecondDimensionWatcherReDive.Client/src/i18n/locales/en/metadataReview.json
@@ -1,0 +1,123 @@
+{
+  "title": "Metadata review center",
+  "subtitle": "Resolve pending, low-confidence, and failed identifications in one place. Review the virtual-path diff before metadata and file mappings are updated atomically.",
+  "tabs": {
+    "aria": "Review categories",
+    "pending": "Pending",
+    "lowConfidence": "Low confidence",
+    "failed": "Failed"
+  },
+  "fields": {
+    "name": "Title",
+    "tmdbId": "TMDB ID",
+    "season": "Season",
+    "episode": "Episode",
+    "groupName": "Release group"
+  },
+  "values": {
+    "notResolved": "Title not identified",
+    "unset": "Not set"
+  },
+  "item": {
+    "confidence": "{{confidence}} confidence",
+    "review": "Review and edit",
+    "seasonEpisode": "S{{season}} · E{{episode}}",
+    "mappedFiles": "{{count}} mapped files",
+    "downloaded": "Download complete",
+    "notDownloaded": "Download incomplete",
+    "retryCount": "{{count}} attempts",
+    "revision": "Revision {{revision}}"
+  },
+  "recent": {
+    "title": "Recent remaps",
+    "subtitle": "Undo a recent atomic remap here, provided no later edit has replaced it.",
+    "revision": "Current revision {{revision}}",
+    "undo": "Undo",
+    "undoing": "Undoing",
+    "unavailable": "Unavailable",
+    "empty": "Undoable remaps will appear here after you complete a review."
+  },
+  "editor": {
+    "title": "Review metadata",
+    "currentMetadata": "Current identification",
+    "currentRevision": "Revision {{revision}}",
+    "unsetHint": "Leave a field blank to clear it. Changing any input after previewing invalidates that preview.",
+    "placeholders": {
+      "tmdbId": "For example, 209867",
+      "season": "For example, 1",
+      "episode": "For example, 12",
+      "groupName": "For example, LoliHouse"
+    },
+    "validation": {
+      "tmdbId": "Enter a valid positive-integer TMDB ID.",
+      "seasonRequired": "A TMDB season is required.",
+      "nonNegativeInteger": "Enter a whole number greater than or equal to 0.",
+      "groupNameLength": "Release group must be 200 characters or fewer."
+    },
+    "errors": {
+      "conflict": "This item changed elsewhere. Close the panel, refresh the list, and review it again (409).",
+      "validation": "The server could not validate this metadata or its paths. Check the input and warnings, then retry (422).",
+      "requestFailed": "The request failed and no changes were applied. Please try again."
+    },
+    "preview": "Preview virtual paths",
+    "previewing": "Generating preview",
+    "refreshPreview": "Regenerate preview",
+    "apply": "Confirm atomic remap",
+    "applying": "Applying"
+  },
+  "preview": {
+    "title": "Pre-apply preview",
+    "revisionAndExpiry": "Based on revision {{revision}} · expires at {{expiresAt}}",
+    "ready": "Ready to apply",
+    "blocked": "Cannot apply",
+    "resolvedMetadata": "Server-resolved metadata",
+    "warnings": "Attention required",
+    "pathChanges": "Virtual-path changes ({{count}})",
+    "noPathChanges": "This item has no files to remap; its metadata can still be updated from this preview.",
+    "noPath": "(no path)",
+    "collisionAdjusted": "A path collision was detected, so the server adjusted the destination filename.",
+    "changeKinds": {
+      "added": "Added",
+      "moved": "Moved",
+      "unchanged": "Unchanged",
+      "removed": "Removed"
+    },
+    "warningCodes": {
+      "notDownloaded": "The download is incomplete, so only metadata will change and existing file mappings will be preserved.",
+      "unresolvedFiles": "Some files could not be identified and will use the unknown-file virtual-path rule."
+    }
+  },
+  "toast": {
+    "applied": "Metadata and file mappings updated",
+    "appliedDetail": "Revision {{revision}} with {{count}} path changes.",
+    "undone": "Remap undone",
+    "undoConflict": "Cannot undo: this item has a newer update (409)",
+    "undoValidation": "Cannot undo: the former paths cannot be restored (422)",
+    "undoFailed": "Undo failed. Please try again."
+  },
+  "queue": {
+    "total": "{{count}} items",
+    "loading": "Loading the review queue…",
+    "page": "Page {{page}} of {{total}}",
+    "pending": {
+      "title": "Awaiting identification",
+      "emptyTitle": "No pending items",
+      "emptyBody": "Every new item is identified or has moved to another review category."
+    },
+    "lowConfidence": {
+      "title": "Low-confidence results",
+      "emptyTitle": "No low-confidence items",
+      "emptyBody": "There are no low-confidence identifications awaiting confirmation."
+    },
+    "failed": {
+      "title": "Failed identifications",
+      "emptyTitle": "No failed items",
+      "emptyBody": "There are no failed identifications or items at their retry limit."
+    }
+  },
+  "errors": {
+    "loadFailed": "Could not load the review queue",
+    "loadFailedDetail": "The latest review state is unavailable. Check the service connection and retry.",
+    "retry": "Reload"
+  }
+}

--- a/SecondDimensionWatcherReDive.Client/src/i18n/locales/ja/common.json
+++ b/SecondDimensionWatcherReDive.Client/src/i18n/locales/ja/common.json
@@ -7,6 +7,7 @@
     "files": "ファイル一覧",
     "feeds": "フィード管理",
     "tasks": "バックグラウンドタスク",
+    "metadataReview": "メタデータ確認",
     "chat": "AI アシスタント",
     "settings": "設定",
     "menu": "メニューを開く"

--- a/SecondDimensionWatcherReDive.Client/src/i18n/locales/ja/metadataReview.json
+++ b/SecondDimensionWatcherReDive.Client/src/i18n/locales/ja/metadataReview.json
@@ -1,0 +1,123 @@
+{
+  "title": "メタデータ確認センター",
+  "subtitle": "未識別・低信頼度・識別失敗の項目をまとめて処理します。仮想パスの差分を確認してから、メタデータとファイルマッピングを原子的に更新します。",
+  "tabs": {
+    "aria": "確認カテゴリー",
+    "pending": "未識別",
+    "lowConfidence": "低信頼度",
+    "failed": "識別失敗"
+  },
+  "fields": {
+    "name": "作品名",
+    "tmdbId": "TMDB ID",
+    "season": "シーズン",
+    "episode": "話数",
+    "groupName": "字幕グループ"
+  },
+  "values": {
+    "notResolved": "作品未識別",
+    "unset": "未設定"
+  },
+  "item": {
+    "confidence": "信頼度 {{confidence}}",
+    "review": "確認・編集",
+    "seasonEpisode": "S{{season}} · E{{episode}}",
+    "mappedFiles": "マッピング済み {{count}} ファイル",
+    "downloaded": "ダウンロード完了",
+    "notDownloaded": "ダウンロード未完了",
+    "retryCount": "試行 {{count}} 回",
+    "revision": "リビジョン {{revision}}"
+  },
+  "recent": {
+    "title": "最近の再マッピング",
+    "subtitle": "後続の変更が行われていない原子的な再マッピングを元に戻せます。",
+    "revision": "現在のリビジョン {{revision}}",
+    "undo": "元に戻す",
+    "undoing": "元に戻しています",
+    "unavailable": "取り消し不可",
+    "empty": "確認を完了すると、取り消し可能な再マッピングがここに表示されます。"
+  },
+  "editor": {
+    "title": "メタデータを確認",
+    "currentMetadata": "現在の識別結果",
+    "currentRevision": "リビジョン {{revision}}",
+    "unsetHint": "空欄にすると該当フィールドを消去します。プレビュー後に入力を変更すると、そのプレビューは無効になります。",
+    "placeholders": {
+      "tmdbId": "例：209867",
+      "season": "例：1",
+      "episode": "例：12",
+      "groupName": "例：LoliHouse"
+    },
+    "validation": {
+      "tmdbId": "有効な正の整数の TMDB ID を入力してください。",
+      "seasonRequired": "TMDB シーズン番号は必須です。",
+      "nonNegativeInteger": "0 以上の整数を入力してください。",
+      "groupNameLength": "字幕グループ名は 200 文字以内で入力してください。"
+    },
+    "errors": {
+      "conflict": "この項目は別の場所で更新されました。パネルを閉じて一覧を更新し、再度確認してください（409）。",
+      "validation": "サーバーでメタデータまたはパスを検証できませんでした。入力と警告を確認してください（422）。",
+      "requestFailed": "リクエストに失敗し、変更は適用されませんでした。もう一度お試しください。"
+    },
+    "preview": "仮想パスをプレビュー",
+    "previewing": "プレビューを生成中",
+    "refreshPreview": "プレビューを再生成",
+    "apply": "原子的な再マッピングを確定",
+    "applying": "適用中"
+  },
+  "preview": {
+    "title": "適用前プレビュー",
+    "revisionAndExpiry": "リビジョン {{revision}} 基準 · {{expiresAt}} に期限切れ",
+    "ready": "適用できます",
+    "blocked": "適用できません",
+    "resolvedMetadata": "サーバーで解決したメタデータ",
+    "warnings": "注意事項",
+    "pathChanges": "仮想パスの変更（{{count}}）",
+    "noPathChanges": "再マッピング対象のファイルはありません。このプレビューからメタデータだけを更新できます。",
+    "noPath": "（パスなし）",
+    "collisionAdjusted": "パスの競合を検出したため、保存先ファイル名を調整しました。",
+    "changeKinds": {
+      "added": "追加",
+      "moved": "移動",
+      "unchanged": "変更なし",
+      "removed": "削除"
+    },
+    "warningCodes": {
+      "notDownloaded": "ダウンロードが未完了のため、メタデータだけを更新し、既存のファイルマッピングは変更しません。",
+      "unresolvedFiles": "一部のファイルを識別できなかったため、不明ファイル用の仮想パス規則を使用します。"
+    }
+  },
+  "toast": {
+    "applied": "メタデータとファイルマッピングを更新しました",
+    "appliedDetail": "リビジョン {{revision}}、{{count}} 件のパス変更を処理しました。",
+    "undone": "再マッピングを元に戻しました",
+    "undoConflict": "元に戻せません：この項目には新しい更新があります（409）",
+    "undoValidation": "元に戻せません：以前のパスを復元できません（422）",
+    "undoFailed": "元に戻せませんでした。もう一度お試しください。"
+  },
+  "queue": {
+    "total": "{{count}} 件",
+    "loading": "確認キューを読み込み中…",
+    "page": "{{page}} / {{total}} ページ",
+    "pending": {
+      "title": "識別待ち",
+      "emptyTitle": "未識別の項目はありません",
+      "emptyBody": "すべての新しい項目が識別済み、または別の確認カテゴリーに移動しました。"
+    },
+    "lowConfidence": {
+      "title": "低信頼度の結果",
+      "emptyTitle": "低信頼度の項目はありません",
+      "emptyBody": "手動確認が必要な低信頼度の識別結果はありません。"
+    },
+    "failed": {
+      "title": "識別失敗の項目",
+      "emptyTitle": "識別失敗の項目はありません",
+      "emptyBody": "識別失敗または再試行上限に達した項目はありません。"
+    }
+  },
+  "errors": {
+    "loadFailed": "確認キューを読み込めませんでした",
+    "loadFailedDetail": "最新の確認状態を取得できません。サービスへの接続を確認して再試行してください。",
+    "retry": "再読み込み"
+  }
+}

--- a/SecondDimensionWatcherReDive.Client/src/i18n/locales/zh-CN/common.json
+++ b/SecondDimensionWatcherReDive.Client/src/i18n/locales/zh-CN/common.json
@@ -7,6 +7,7 @@
     "files": "文件浏览",
     "feeds": "订阅管理",
     "tasks": "后台任务",
+    "metadataReview": "元数据审核",
     "chat": "AI 助手",
     "settings": "设置",
     "menu": "打开导航"

--- a/SecondDimensionWatcherReDive.Client/src/i18n/locales/zh-CN/metadataReview.json
+++ b/SecondDimensionWatcherReDive.Client/src/i18n/locales/zh-CN/metadataReview.json
@@ -1,0 +1,123 @@
+{
+  "title": "元数据审核中心",
+  "subtitle": "集中处理待识别、低置信度与识别失败的项目。修改元数据后先核对虚拟路径差异，再以一次原子操作更新文件映射。",
+  "tabs": {
+    "aria": "审核分类",
+    "pending": "待识别",
+    "lowConfidence": "低置信度",
+    "failed": "识别失败"
+  },
+  "fields": {
+    "name": "作品名",
+    "tmdbId": "TMDB ID",
+    "season": "季",
+    "episode": "集",
+    "groupName": "字幕组"
+  },
+  "values": {
+    "notResolved": "尚未识别作品",
+    "unset": "未设置"
+  },
+  "item": {
+    "confidence": "置信度 {{confidence}}",
+    "review": "审核并修改",
+    "seasonEpisode": "S{{season}} · E{{episode}}",
+    "mappedFiles": "{{count}} 个映射文件",
+    "downloaded": "下载已完成",
+    "notDownloaded": "尚未完成下载",
+    "retryCount": "已尝试 {{count}} 次",
+    "revision": "版本 {{revision}}"
+  },
+  "recent": {
+    "title": "最近重映射",
+    "subtitle": "在后续修改发生前，可从这里撤销最近的原子重映射。",
+    "revision": "当前版本 {{revision}}",
+    "undo": "撤销",
+    "undoing": "正在撤销",
+    "unavailable": "不可撤销",
+    "empty": "完成一次审核后，可撤销的重映射会显示在这里。"
+  },
+  "editor": {
+    "title": "审核元数据",
+    "currentMetadata": "当前识别结果",
+    "currentRevision": "版本 {{revision}}",
+    "unsetHint": "留空会清除对应字段。预览生成后，只要修改任一输入，就必须重新预览。",
+    "placeholders": {
+      "tmdbId": "例如 209867",
+      "season": "例如 1",
+      "episode": "例如 12",
+      "groupName": "例如 LoliHouse"
+    },
+    "validation": {
+      "tmdbId": "请输入有效的正整数 TMDB ID。",
+      "seasonRequired": "必须填写 TMDB 季编号。",
+      "nonNegativeInteger": "请输入大于或等于 0 的整数。",
+      "groupNameLength": "字幕组名称不能超过 200 个字符。"
+    },
+    "errors": {
+      "conflict": "项目已在其他位置更新。请关闭面板、刷新列表后重新审核（409）。",
+      "validation": "服务器无法验证这些元数据或路径，请检查输入与警告后重试（422）。",
+      "requestFailed": "请求失败，当前更改尚未应用。请稍后重试。"
+    },
+    "preview": "预览虚拟路径",
+    "previewing": "正在生成预览",
+    "refreshPreview": "重新生成预览",
+    "apply": "确认并原子重映射",
+    "applying": "正在应用"
+  },
+  "preview": {
+    "title": "应用前预览",
+    "revisionAndExpiry": "基于版本 {{revision}} · 预览于 {{expiresAt}} 过期",
+    "ready": "可安全应用",
+    "blocked": "暂不可应用",
+    "resolvedMetadata": "服务器解析后的元数据",
+    "warnings": "需要注意",
+    "pathChanges": "虚拟路径变更（{{count}}）",
+    "noPathChanges": "这个项目没有需要重映射的文件；元数据仍可按预览结果更新。",
+    "noPath": "（无路径）",
+    "collisionAdjusted": "检测到路径冲突，服务器已自动调整目标文件名。",
+    "changeKinds": {
+      "added": "新增",
+      "moved": "移动",
+      "unchanged": "不变",
+      "removed": "移除"
+    },
+    "warningCodes": {
+      "notDownloaded": "下载尚未完成，本次只更新元数据，不会改动现有文件映射。",
+      "unresolvedFiles": "部分文件无法识别，将按未知文件规则生成虚拟路径。"
+    }
+  },
+  "toast": {
+    "applied": "元数据与文件映射已更新",
+    "appliedDetail": "版本 {{revision}}，处理了 {{count}} 条路径变更。",
+    "undone": "重映射已撤销",
+    "undoConflict": "无法撤销：项目已有更新（409）",
+    "undoValidation": "无法撤销：原路径无法恢复（422）",
+    "undoFailed": "撤销失败，请稍后重试"
+  },
+  "queue": {
+    "total": "共 {{count}} 个项目",
+    "loading": "正在读取审核队列…",
+    "page": "第 {{page}} / {{total}} 页",
+    "pending": {
+      "title": "等待人工识别",
+      "emptyTitle": "没有待识别项目",
+      "emptyBody": "当前所有新项目都已完成识别或进入其他审核分类。"
+    },
+    "lowConfidence": {
+      "title": "低置信度结果",
+      "emptyTitle": "没有低置信度项目",
+      "emptyBody": "当前没有需要人工确认的低置信度识别结果。"
+    },
+    "failed": {
+      "title": "识别失败项目",
+      "emptyTitle": "没有识别失败项目",
+      "emptyBody": "当前没有达到重试上限或识别失败的项目。"
+    }
+  },
+  "errors": {
+    "loadFailed": "审核队列加载失败",
+    "loadFailedDetail": "无法读取最新审核状态，请检查服务连接后重试。",
+    "retry": "重新加载"
+  }
+}

--- a/SecondDimensionWatcherReDive.Client/src/i18n/resources.ts
+++ b/SecondDimensionWatcherReDive.Client/src/i18n/resources.ts
@@ -1,15 +1,3 @@
-import zhCnAnimation from "./locales/zh-CN/animation.json";
-import zhCnAuth from "./locales/zh-CN/auth.json";
-import zhCnChat from "./locales/zh-CN/chat.json";
-import zhCnCommon from "./locales/zh-CN/common.json";
-import zhCnErrors from "./locales/zh-CN/errors.json";
-import zhCnFeeds from "./locales/zh-CN/feeds.json";
-import zhCnFiles from "./locales/zh-CN/files.json";
-import zhCnPlayer from "./locales/zh-CN/player.json";
-import zhCnSeason from "./locales/zh-CN/season.json";
-import zhCnSettings from "./locales/zh-CN/settings.json";
-import zhCnTasks from "./locales/zh-CN/tasks.json";
-
 import enAnimation from "./locales/en/animation.json";
 import enAuth from "./locales/en/auth.json";
 import enChat from "./locales/en/chat.json";
@@ -17,11 +5,11 @@ import enCommon from "./locales/en/common.json";
 import enErrors from "./locales/en/errors.json";
 import enFeeds from "./locales/en/feeds.json";
 import enFiles from "./locales/en/files.json";
+import enMetadataReview from "./locales/en/metadataReview.json";
 import enPlayer from "./locales/en/player.json";
 import enSeason from "./locales/en/season.json";
 import enSettings from "./locales/en/settings.json";
 import enTasks from "./locales/en/tasks.json";
-
 import jaAnimation from "./locales/ja/animation.json";
 import jaAuth from "./locales/ja/auth.json";
 import jaChat from "./locales/ja/chat.json";
@@ -29,10 +17,23 @@ import jaCommon from "./locales/ja/common.json";
 import jaErrors from "./locales/ja/errors.json";
 import jaFeeds from "./locales/ja/feeds.json";
 import jaFiles from "./locales/ja/files.json";
+import jaMetadataReview from "./locales/ja/metadataReview.json";
 import jaPlayer from "./locales/ja/player.json";
 import jaSeason from "./locales/ja/season.json";
 import jaSettings from "./locales/ja/settings.json";
 import jaTasks from "./locales/ja/tasks.json";
+import zhCnAnimation from "./locales/zh-CN/animation.json";
+import zhCnAuth from "./locales/zh-CN/auth.json";
+import zhCnChat from "./locales/zh-CN/chat.json";
+import zhCnCommon from "./locales/zh-CN/common.json";
+import zhCnErrors from "./locales/zh-CN/errors.json";
+import zhCnFeeds from "./locales/zh-CN/feeds.json";
+import zhCnFiles from "./locales/zh-CN/files.json";
+import zhCnMetadataReview from "./locales/zh-CN/metadataReview.json";
+import zhCnPlayer from "./locales/zh-CN/player.json";
+import zhCnSeason from "./locales/zh-CN/season.json";
+import zhCnSettings from "./locales/zh-CN/settings.json";
+import zhCnTasks from "./locales/zh-CN/tasks.json";
 
 export const resources = {
   "zh-cn": {
@@ -41,6 +42,7 @@ export const resources = {
     errors: zhCnErrors,
     animation: zhCnAnimation,
     files: zhCnFiles,
+    metadataReview: zhCnMetadataReview,
     chat: zhCnChat,
     feeds: zhCnFeeds,
     season: zhCnSeason,
@@ -54,6 +56,7 @@ export const resources = {
     errors: enErrors,
     animation: enAnimation,
     files: enFiles,
+    metadataReview: enMetadataReview,
     chat: enChat,
     feeds: enFeeds,
     season: enSeason,
@@ -67,6 +70,7 @@ export const resources = {
     errors: jaErrors,
     animation: jaAnimation,
     files: jaFiles,
+    metadataReview: jaMetadataReview,
     chat: jaChat,
     feeds: jaFeeds,
     season: jaSeason,

--- a/SecondDimensionWatcherReDive.Client/src/metadataReview/api.ts
+++ b/SecondDimensionWatcherReDive.Client/src/metadataReview/api.ts
@@ -1,0 +1,69 @@
+import useSWR from "swr";
+
+import fetcher from "../auth/httpClient";
+import {
+  EditableMetadata,
+  MetadataRemapResult,
+  MetadataReviewPreview,
+  MetadataReviewResponse,
+  MetadataReviewStatus,
+} from "./types";
+
+export const METADATA_REVIEW_PAGE_SIZE = 20;
+
+export function useMetadataReview(status: MetadataReviewStatus, page: number) {
+  const skip = (page - 1) * METADATA_REVIEW_PAGE_SIZE;
+  const query = new URLSearchParams({
+    status,
+    skip: String(skip),
+    take: String(METADATA_REVIEW_PAGE_SIZE),
+  });
+
+  return useSWR<MetadataReviewResponse>(
+    `/api/metadata-review?${query.toString()}`,
+    fetcher,
+  );
+}
+
+export function previewMetadataReview(
+  id: string,
+  expectedRevision: number,
+  metadata: EditableMetadata,
+): Promise<MetadataReviewPreview> {
+  return fetcher(`/api/metadata-review/${encodeURIComponent(id)}/preview`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ expectedRevision, metadata }),
+  });
+}
+
+export function applyMetadataReview(
+  id: string,
+  previewId: string,
+): Promise<MetadataRemapResult> {
+  return fetcher(`/api/metadata-review/${encodeURIComponent(id)}/apply`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ previewId }),
+  });
+}
+
+export function undoMetadataRemap(
+  operationId: string,
+  expectedRevision: number,
+): Promise<MetadataRemapResult> {
+  return fetcher(
+    `/api/metadata-review/remaps/${encodeURIComponent(operationId)}/undo`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ expectedRevision }),
+    },
+  );
+}
+
+export function metadataReviewErrorStatus(error: unknown): number | null {
+  if (!(error instanceof Error)) return null;
+  const match = error.message.match(/\b(\d{3})\b/);
+  return match ? Number(match[1]) : null;
+}

--- a/SecondDimensionWatcherReDive.Client/src/metadataReview/types.ts
+++ b/SecondDimensionWatcherReDive.Client/src/metadataReview/types.ts
@@ -1,0 +1,84 @@
+export type MetadataReviewStatus = "pending" | "lowConfidence" | "failed";
+
+export interface MetadataReviewMetadata {
+  tmdbId: string | null;
+  name: string | null;
+  originalName: string | null;
+  posterPath: string | null;
+  season: number | null;
+  episode: number | null;
+  groupName: string | null;
+}
+
+export interface MetadataReviewItem {
+  id: string;
+  title: string;
+  description: string | null;
+  publishTime: string;
+  reviewStatus: MetadataReviewStatus;
+  confidence: number | null;
+  failureReason: string | null;
+  aiRetryCount: number;
+  metadata: MetadataReviewMetadata;
+  isDownloadFinished: boolean;
+  mappedFileCount: number;
+  revision: number;
+  currentOperationId?: string | null;
+}
+
+export interface MetadataReviewCounts {
+  pending: number;
+  lowConfidence: number;
+  failed: number;
+}
+
+export interface MetadataReviewOperation {
+  operationId: string;
+  itemId: string;
+  title: string;
+  appliedAt: string;
+  revision: number;
+  canUndo: boolean;
+}
+
+export interface MetadataReviewResponse {
+  data: MetadataReviewItem[];
+  totalItems: number;
+  counts: MetadataReviewCounts;
+  recentOperations: MetadataReviewOperation[];
+}
+
+export interface EditableMetadata {
+  tmdbId: string | null;
+  season: number | null;
+  episode: number | null;
+  groupName: string | null;
+}
+
+export type PathChangeKind = "added" | "moved" | "unchanged" | "removed";
+
+export interface MetadataPathChange {
+  fileName: string;
+  currentVirtualPath: string | null;
+  proposedVirtualPath: string | null;
+  changeKind: PathChangeKind;
+  collisionAdjusted: boolean;
+}
+
+export interface MetadataReviewPreview {
+  previewId: string;
+  baseRevision: number;
+  resolvedMetadata: MetadataReviewMetadata;
+  pathChanges: MetadataPathChange[];
+  warnings: string[];
+  canApply: boolean;
+  expiresAt: string;
+}
+
+export interface MetadataRemapResult {
+  operationId: string;
+  revision: number;
+  pathChanges: MetadataPathChange[];
+  appliedAt: string;
+  canUndo: boolean;
+}

--- a/SecondDimensionWatcherReDive.Client/src/pages/MetadataReviewPage.tsx
+++ b/SecondDimensionWatcherReDive.Client/src/pages/MetadataReviewPage.tsx
@@ -1,0 +1,533 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { useSearchParams } from "react-router";
+
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  Edit3,
+  FileQuestion,
+  Files,
+  History,
+  RefreshCw,
+  RotateCcw,
+} from "lucide-react";
+
+import { tmdbImageUrl } from "../animation/tmdbImage";
+import { MetadataReviewSheet } from "../components/MetadataReviewSheet";
+import { useToast } from "../components/ToastProvider";
+import { Button } from "../components/ui/Button";
+import { EmptyPrompt } from "../components/ui/EmptyPrompt";
+import { Pagination } from "../components/ui/Pagination";
+import { Spinner } from "../components/ui/Spinner";
+import { cn } from "../lib/cn";
+import {
+  METADATA_REVIEW_PAGE_SIZE,
+  metadataReviewErrorStatus,
+  undoMetadataRemap,
+  useMetadataReview,
+} from "../metadataReview/api";
+import {
+  MetadataRemapResult,
+  MetadataReviewCounts,
+  MetadataReviewItem,
+  MetadataReviewOperation,
+  MetadataReviewStatus,
+} from "../metadataReview/types";
+import { PageTemplate } from "./PageTemplate";
+
+const REVIEW_STATUSES: MetadataReviewStatus[] = [
+  "pending",
+  "lowConfidence",
+  "failed",
+];
+
+const EMPTY_COUNTS: MetadataReviewCounts = {
+  pending: 0,
+  lowConfidence: 0,
+  failed: 0,
+};
+
+function parseStatus(value: string | null): MetadataReviewStatus {
+  return REVIEW_STATUSES.includes(value as MetadataReviewStatus)
+    ? (value as MetadataReviewStatus)
+    : "pending";
+}
+
+function parsePage(value: string | null): number {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : 1;
+}
+
+interface StatusTabsProps {
+  active: MetadataReviewStatus;
+  counts: MetadataReviewCounts;
+  countsLoaded: boolean;
+  onChange: (status: MetadataReviewStatus) => void;
+}
+
+const StatusTabs: React.FC<StatusTabsProps> = ({
+  active,
+  counts,
+  countsLoaded,
+  onChange,
+}) => {
+  const { t } = useTranslation("metadataReview");
+
+  return (
+    <div
+      role="tablist"
+      aria-label={t("tabs.aria")}
+      className="grid grid-cols-3 gap-2 rounded-xl border border-border-light bg-surface p-1.5 shadow-whisper"
+    >
+      {REVIEW_STATUSES.map((status) => (
+        <button
+          key={status}
+          type="button"
+          role="tab"
+          aria-selected={active === status}
+          onClick={() => onChange(status)}
+          className={cn(
+            "flex min-w-0 items-center justify-center gap-2 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors",
+            active === status
+              ? "bg-canvas text-foreground shadow-ring"
+              : "text-muted hover:bg-canvas/60 hover:text-foreground",
+          )}
+        >
+          <span className="truncate">{t(`tabs.${status}`)}</span>
+          <span
+            className={cn(
+              "min-w-6 rounded-full px-1.5 py-0.5 text-center text-xs tabular-nums",
+              active === status
+                ? "bg-brand/10 text-brand"
+                : "bg-canvas text-subtle",
+            )}
+          >
+            {countsLoaded ? counts[status] : "…"}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+};
+
+function confidenceLabel(confidence: number | null): string | null {
+  if (confidence == null || !Number.isFinite(confidence)) return null;
+  const percentage = confidence <= 1 ? confidence * 100 : confidence;
+  return `${Math.round(percentage)}%`;
+}
+
+interface ReviewItemRowProps {
+  item: MetadataReviewItem;
+  onEdit: () => void;
+}
+
+const ReviewItemRow: React.FC<ReviewItemRowProps> = ({ item, onEdit }) => {
+  const { t } = useTranslation("metadataReview");
+  const poster = tmdbImageUrl(item.metadata.posterPath, "w185");
+  const confidence = confidenceLabel(item.confidence);
+
+  return (
+    <article className="group p-4 sm:p-5">
+      <div className="flex items-start gap-4">
+        <div className="hidden h-24 w-16 shrink-0 overflow-hidden rounded-lg bg-canvas sm:block">
+          {poster ? (
+            <img
+              src={poster}
+              alt=""
+              className="h-full w-full object-cover"
+              loading="lazy"
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center text-subtle">
+              <FileQuestion size={22} />
+            </div>
+          )}
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <span
+                  className={cn(
+                    "rounded-full px-2 py-0.5 text-xs font-medium",
+                    item.reviewStatus === "failed"
+                      ? "bg-error/10 text-error"
+                      : item.reviewStatus === "lowConfidence"
+                        ? "bg-warning/15 text-warning"
+                        : "bg-brand/10 text-brand",
+                  )}
+                >
+                  {t(`tabs.${item.reviewStatus}`)}
+                </span>
+                {confidence ? (
+                  <span className="text-xs text-subtle">
+                    {t("item.confidence", { confidence })}
+                  </span>
+                ) : null}
+                <span className="text-xs text-subtle">
+                  {new Date(item.publishTime).toLocaleString()}
+                </span>
+              </div>
+              <h3
+                className="mt-2 line-clamp-2 font-serif text-base font-medium leading-heading text-foreground sm:text-lg"
+                title={item.title}
+              >
+                {item.title}
+              </h3>
+              {item.description ? (
+                <p className="mt-1 line-clamp-2 text-sm leading-body text-muted">
+                  {item.description}
+                </p>
+              ) : null}
+            </div>
+
+            <Button
+              variant="outline"
+              size="sm"
+              className="shrink-0 self-start"
+              onClick={onEdit}
+            >
+              <Edit3 size={15} />
+              {t("item.review")}
+            </Button>
+          </div>
+
+          {item.failureReason ? (
+            <div className="mt-3 flex items-start gap-2 rounded-lg bg-error/8 px-3 py-2 text-sm text-error">
+              <AlertTriangle size={15} className="mt-0.5 shrink-0" />
+              <span>{item.failureReason}</span>
+            </div>
+          ) : null}
+
+          <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2 text-xs text-muted">
+            <span>
+              <strong className="font-medium text-foreground">
+                {item.metadata.name ?? t("values.notResolved")}
+              </strong>
+              {item.metadata.originalName ? (
+                <span className="ml-1 text-subtle">
+                  · {item.metadata.originalName}
+                </span>
+              ) : null}
+            </span>
+            <span>
+              {t("fields.tmdbId")}: {item.metadata.tmdbId ?? t("values.unset")}
+            </span>
+            <span>
+              {t("item.seasonEpisode", {
+                season: item.metadata.season ?? "—",
+                episode: item.metadata.episode ?? "—",
+              })}
+            </span>
+            <span>
+              {t("fields.groupName")}:{" "}
+              {item.metadata.groupName ?? t("values.unset")}
+            </span>
+          </div>
+
+          <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-border-light pt-3 text-xs text-subtle">
+            <span className="inline-flex items-center gap-1.5">
+              <Files size={13} />
+              {t("item.mappedFiles", { count: item.mappedFileCount })}
+            </span>
+            <span className="text-border">·</span>
+            <span
+              className={
+                item.isDownloadFinished ? "text-success" : "text-subtle"
+              }
+            >
+              {item.isDownloadFinished
+                ? t("item.downloaded")
+                : t("item.notDownloaded")}
+            </span>
+            <span className="text-border">·</span>
+            <span>{t("item.retryCount", { count: item.aiRetryCount })}</span>
+            <span className="text-border">·</span>
+            <span>{t("item.revision", { revision: item.revision })}</span>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+interface RecentOperationsProps {
+  operations: MetadataReviewOperation[];
+  undoing: Set<string>;
+  onUndo: (operation: MetadataReviewOperation) => void;
+}
+
+const RecentOperations: React.FC<RecentOperationsProps> = ({
+  operations,
+  undoing,
+  onUndo,
+}) => {
+  const { t } = useTranslation("metadataReview");
+
+  return (
+    <section className="mt-6 rounded-xl border border-border-light bg-surface p-4 shadow-whisper sm:p-5">
+      <div className="flex items-start gap-3">
+        <span className="rounded-lg bg-canvas p-2 text-muted">
+          <History size={18} />
+        </span>
+        <div>
+          <h2 className="font-serif text-base font-medium text-foreground">
+            {t("recent.title")}
+          </h2>
+          <p className="mt-0.5 text-sm text-muted">{t("recent.subtitle")}</p>
+        </div>
+      </div>
+
+      {operations.length > 0 ? (
+        <ul className="mt-4 divide-y divide-border-light border-t border-border-light">
+          {operations.map((operation) => {
+            const busy = undoing.has(operation.operationId);
+            return (
+              <li
+                key={operation.operationId}
+                className="flex flex-col gap-3 py-3 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-foreground">
+                    {operation.title}
+                  </p>
+                  <p className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-subtle">
+                    <span className="inline-flex items-center gap-1">
+                      <Clock3 size={12} />
+                      {new Date(operation.appliedAt).toLocaleString()}
+                    </span>
+                    <span>
+                      {t("recent.revision", { revision: operation.revision })}
+                    </span>
+                  </p>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="shrink-0 self-start sm:self-auto"
+                  disabled={!operation.canUndo || busy}
+                  onClick={() => onUndo(operation)}
+                >
+                  {busy ? <Spinner size={14} /> : <RotateCcw size={14} />}
+                  {busy
+                    ? t("recent.undoing")
+                    : operation.canUndo
+                      ? t("recent.undo")
+                      : t("recent.unavailable")}
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <p className="mt-4 border-t border-border-light pt-4 text-sm text-subtle">
+          {t("recent.empty")}
+        </p>
+      )}
+    </section>
+  );
+};
+
+export const MetadataReviewPage: React.FC = () => {
+  const { t } = useTranslation("metadataReview");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const status = parseStatus(searchParams.get("status"));
+  const page = parsePage(searchParams.get("page"));
+  const { data, error, isLoading, mutate } = useMetadataReview(status, page);
+  const { addToast } = useToast();
+  const [selectedItem, setSelectedItem] =
+    React.useState<MetadataReviewItem | null>(null);
+  const [undoing, setUndoing] = React.useState<Set<string>>(new Set());
+
+  const updateLocation = React.useCallback(
+    (nextStatus: MetadataReviewStatus, nextPage: number) => {
+      const next = new URLSearchParams(searchParams);
+      if (nextStatus === "pending") next.delete("status");
+      else next.set("status", nextStatus);
+      if (nextPage === 1) next.delete("page");
+      else next.set("page", String(nextPage));
+      setSearchParams(next);
+    },
+    [searchParams, setSearchParams],
+  );
+
+  React.useEffect(() => {
+    if (!data) return;
+    const lastPage = Math.max(
+      1,
+      Math.ceil(data.totalItems / METADATA_REVIEW_PAGE_SIZE),
+    );
+    if (page > lastPage) updateLocation(status, lastPage);
+  }, [data, page, status, updateLocation]);
+
+  const changeStatus = React.useCallback(
+    (nextStatus: MetadataReviewStatus) => {
+      setSelectedItem(null);
+      updateLocation(nextStatus, 1);
+    },
+    [updateLocation],
+  );
+
+  const handleApplied = React.useCallback(
+    async (result: MetadataRemapResult) => {
+      setSelectedItem(null);
+      await mutate();
+      addToast({
+        title: t("toast.applied"),
+        text: t("toast.appliedDetail", {
+          count: result.pathChanges.length,
+          revision: result.revision,
+        }),
+        color: "success",
+      });
+    },
+    [addToast, mutate, t],
+  );
+
+  const handleUndo = React.useCallback(
+    async (operation: MetadataReviewOperation) => {
+      setUndoing((current) => new Set(current).add(operation.operationId));
+      try {
+        await undoMetadataRemap(operation.operationId, operation.revision);
+        await mutate();
+        addToast({ title: t("toast.undone"), color: "success" });
+      } catch (undoError) {
+        const statusCode = metadataReviewErrorStatus(undoError);
+        addToast({
+          title:
+            statusCode === 409
+              ? t("toast.undoConflict")
+              : statusCode === 422
+                ? t("toast.undoValidation")
+                : t("toast.undoFailed"),
+          color: "danger",
+        });
+      } finally {
+        setUndoing((current) => {
+          const next = new Set(current);
+          next.delete(operation.operationId);
+          return next;
+        });
+      }
+    },
+    [addToast, mutate, t],
+  );
+
+  const counts = data?.counts ?? EMPTY_COUNTS;
+  const pageCount = data
+    ? Math.ceil(data.totalItems / METADATA_REVIEW_PAGE_SIZE)
+    : 0;
+
+  return (
+    <PageTemplate>
+      <header className="max-w-3xl">
+        <h1 className="font-serif text-2xl font-medium leading-heading text-foreground">
+          {t("title")}
+        </h1>
+        <p className="mt-2 text-sm leading-body text-muted">{t("subtitle")}</p>
+      </header>
+
+      <div className="mt-6">
+        <StatusTabs
+          active={status}
+          counts={counts}
+          countsLoaded={!!data}
+          onChange={changeStatus}
+        />
+      </div>
+
+      <RecentOperations
+        operations={data?.recentOperations ?? []}
+        undoing={undoing}
+        onUndo={handleUndo}
+      />
+
+      <section className="mt-8">
+        <div className="mb-3 flex items-end justify-between gap-3">
+          <div>
+            <h2 className="font-serif text-lg font-medium text-foreground">
+              {t(`queue.${status}.title`)}
+            </h2>
+            <p className="mt-1 text-sm text-muted">
+              {data
+                ? t("queue.total", { count: data.totalItems })
+                : t("queue.loading")}
+            </p>
+          </div>
+          {data ? (
+            <span className="text-xs text-subtle">
+              {t("queue.page", {
+                page,
+                total: Math.max(1, pageCount),
+              })}
+            </span>
+          ) : null}
+        </div>
+
+        <div className="overflow-hidden rounded-xl border border-border-light bg-surface shadow-whisper">
+          {error ? (
+            <EmptyPrompt
+              icon={<AlertTriangle size={42} />}
+              title={<h3>{t("errors.loadFailed")}</h3>}
+              body={
+                <div>
+                  <p>{t("errors.loadFailedDetail")}</p>
+                  <Button
+                    className="mt-4"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void mutate()}
+                  >
+                    <RefreshCw size={14} />
+                    {t("errors.retry")}
+                  </Button>
+                </div>
+              }
+            />
+          ) : isLoading || !data ? (
+            <div className="flex justify-center py-20">
+              <Spinner />
+            </div>
+          ) : data.data.length === 0 ? (
+            <EmptyPrompt
+              icon={<CheckCircle2 size={42} />}
+              title={<h3>{t(`queue.${status}.emptyTitle`)}</h3>}
+              body={<p>{t(`queue.${status}.emptyBody`)}</p>}
+            />
+          ) : (
+            <div className="divide-y divide-border-light">
+              {data.data.map((item) => (
+                <ReviewItemRow
+                  key={item.id}
+                  item={item}
+                  onEdit={() => setSelectedItem(item)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {pageCount > 1 ? (
+          <div className="mt-5 flex justify-center">
+            <Pagination
+              pageCount={pageCount}
+              activePage={page - 1}
+              onPageClick={(nextPage) => updateLocation(status, nextPage + 1)}
+            />
+          </div>
+        ) : null}
+      </section>
+
+      <MetadataReviewSheet
+        item={selectedItem}
+        onOpenChange={(open) => {
+          if (!open) setSelectedItem(null);
+        }}
+        onApplied={handleApplied}
+      />
+    </PageTemplate>
+  );
+};

--- a/SecondDimensionWatcherReDive.Framework/DataRepository/AnimationInfo.cs
+++ b/SecondDimensionWatcherReDive.Framework/DataRepository/AnimationInfo.cs
@@ -20,4 +20,10 @@ public sealed record AnimationInfo(
     AnimationGroup? Group,
     Animation? Animation,
     bool IsAiProcessed,
-    int AiRetryCount);
+    int AiRetryCount,
+    MetadataReviewStatus MetadataStatus = MetadataReviewStatus.Pending,
+    double? MetadataConfidence = null,
+    string? MetadataLastError = null,
+    DateTimeOffset? MetadataReviewedAt = null,
+    long StateVersion = 0,
+    Guid? CurrentMetadataReviewOperationId = null);

--- a/SecondDimensionWatcherReDive.Framework/DataRepository/IAnimationInfoRepository.cs
+++ b/SecondDimensionWatcherReDive.Framework/DataRepository/IAnimationInfoRepository.cs
@@ -23,4 +23,9 @@ public interface IAnimationInfoRepository
     Task AddAsync(AnimationInfo info, CancellationToken cancellationToken);
 
     Task UpdateAsync(AnimationInfo info, CancellationToken cancellationToken);
+
+    Task<bool> TryUpdateAsync(
+        AnimationInfo info,
+        long expectedStateVersion,
+        CancellationToken cancellationToken);
 }

--- a/SecondDimensionWatcherReDive.Framework/DataRepository/IFileMappingRepository.cs
+++ b/SecondDimensionWatcherReDive.Framework/DataRepository/IFileMappingRepository.cs
@@ -6,9 +6,14 @@ public interface IFileMappingRepository
 
     Task<bool> ReplaceForAnimationInfoAsync(
         Guid animationInfoId,
+        long expectedStateVersion,
         string expectedFileStore,
         string expectedStorePath,
         IReadOnlyList<FileMapping> mappings,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<FileMapping>> GetForAnimationInfoAsync(
+        Guid animationInfoId,
         CancellationToken cancellationToken);
 
     Task<FileMapping?> FindByVirtualPathAsync(string virtualPath, CancellationToken cancellationToken);

--- a/SecondDimensionWatcherReDive.Framework/DataRepository/IMetadataReviewRepository.cs
+++ b/SecondDimensionWatcherReDive.Framework/DataRepository/IMetadataReviewRepository.cs
@@ -1,0 +1,24 @@
+namespace SecondDimensionWatcherReDive.Framework.DataRepository;
+
+public interface IMetadataReviewRepository
+{
+    Task<MetadataReviewQueuePage> GetQueueAsync(
+        MetadataReviewStatus status,
+        int skip,
+        int take,
+        CancellationToken cancellationToken);
+
+    Task SavePreviewAsync(
+        MetadataReviewPreviewDraft draft,
+        CancellationToken cancellationToken);
+
+    Task<MetadataReviewMutationResult> ApplyPreviewAsync(
+        Guid operationId,
+        Guid expectedAnimationInfoId,
+        CancellationToken cancellationToken);
+
+    Task<MetadataReviewMutationResult> UndoAsync(
+        Guid operationId,
+        long expectedVersion,
+        CancellationToken cancellationToken);
+}

--- a/SecondDimensionWatcherReDive.Framework/DataRepository/MetadataReview.cs
+++ b/SecondDimensionWatcherReDive.Framework/DataRepository/MetadataReview.cs
@@ -1,0 +1,83 @@
+namespace SecondDimensionWatcherReDive.Framework.DataRepository;
+
+public enum MetadataReviewStatus
+{
+    Pending,
+    Identified,
+    LowConfidence,
+    Failed,
+    Reviewed
+}
+
+public enum MetadataReviewOperationState
+{
+    Draft,
+    Applied,
+    Undone,
+    Expired
+}
+
+public enum MetadataReviewMappingKind
+{
+    Proposed,
+    Previous
+}
+
+public enum MetadataReviewMutationOutcome
+{
+    Success,
+    NotFound,
+    Conflict,
+    Expired
+}
+
+public sealed record MetadataReviewQueueItem(
+    AnimationInfo Info,
+    int MappedFileCount,
+    Guid? CurrentOperationId,
+    DateTimeOffset? CurrentOperationAppliedAt,
+    bool CanUndo);
+
+public sealed record MetadataReviewCounts(
+    int Pending,
+    int LowConfidence,
+    int Failed);
+
+public sealed record MetadataReviewOperationSummary(
+    Guid OperationId,
+    Guid AnimationInfoId,
+    string Title,
+    DateTimeOffset AppliedAt,
+    long Revision,
+    bool CanUndo);
+
+public sealed record MetadataReviewQueuePage(
+    IReadOnlyList<MetadataReviewQueueItem> Data,
+    int TotalCount,
+    MetadataReviewCounts Counts,
+    IReadOnlyList<MetadataReviewOperationSummary> RecentOperations);
+
+public sealed record MetadataReviewPreviewDraft(
+    Guid Id,
+    Guid AnimationInfoId,
+    long BaseVersion,
+    string? BaseFileStore,
+    string? BaseStorePath,
+    bool BaseIsDownloadFinished,
+    Animation ProposedAnimation,
+    string ProposedDescription,
+    int? ProposedSeason,
+    int? ProposedEpisode,
+    string? ProposedGroupName,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset ExpiresAt,
+    IReadOnlyList<FileMapping> ProposedMappings);
+
+public sealed record MetadataReviewMutationResult(
+    MetadataReviewMutationOutcome Outcome,
+    Guid OperationId,
+    Guid? AnimationInfoId,
+    long? Revision,
+    DateTimeOffset? AppliedAt,
+    IReadOnlyList<FileMapping> MappingsBefore,
+    IReadOnlyList<FileMapping> MappingsAfter);

--- a/SecondDimensionWatcherReDive.Framework/Inference/InferenceResult.cs
+++ b/SecondDimensionWatcherReDive.Framework/Inference/InferenceResult.cs
@@ -8,4 +8,5 @@ public record InferenceResult(
     string? TmdbId,
     string? GroupName,
     int? Season,
-    int? Episode);
+    int? Episode,
+    double? Confidence = null);

--- a/SecondDimensionWatcherReDive.IntegrationTest/Helpers/Fakes.cs
+++ b/SecondDimensionWatcherReDive.IntegrationTest/Helpers/Fakes.cs
@@ -22,6 +22,7 @@ internal sealed class FakeFileMappingRepository : IFileMappingRepository
 
     public Task<bool> ReplaceForAnimationInfoAsync(
         Guid animationInfoId,
+        long expectedStateVersion,
         string expectedFileStore,
         string expectedStorePath,
         IReadOnlyList<FileMapping> mappings,
@@ -31,6 +32,12 @@ internal sealed class FakeFileMappingRepository : IFileMappingRepository
         _mappings.AddRange(mappings);
         return Task.FromResult(true);
     }
+
+    public Task<IReadOnlyList<FileMapping>> GetForAnimationInfoAsync(
+        Guid animationInfoId,
+        CancellationToken cancellationToken)
+        => Task.FromResult<IReadOnlyList<FileMapping>>(
+            Snapshot().Where(mapping => mapping.AnimationInfoId == animationInfoId).ToList());
 
     public Task<FileMapping?> FindByVirtualPathAsync(string virtualPath, CancellationToken cancellationToken)
         => Task.FromResult(Snapshot().FirstOrDefault(m => m.VirtualPath == virtualPath));

--- a/SecondDimensionWatcherReDive.Test/FileMapperRegexInferenceTests.cs
+++ b/SecondDimensionWatcherReDive.Test/FileMapperRegexInferenceTests.cs
@@ -10,6 +10,8 @@ namespace SecondDimensionWatcherReDive.Test;
 [TestClass]
 public class FileMapperRegexInferenceTests
 {
+    private const long ExpectedStateVersion = 7;
+
     private static readonly string[] VideoFileNames =
     [
         "Anime - 01.mkv",
@@ -41,6 +43,7 @@ public class FileMapperRegexInferenceTests
             It.IsAny<CancellationToken>()), Times.Never);
         fixture.FileMappingRepository.Verify(repository => repository.ReplaceForAnimationInfoAsync(
             fixture.AnimationInfoId,
+            ExpectedStateVersion,
             "test-store",
             "/downloads/anime",
             It.Is<IReadOnlyList<FileMapping>>(mappings =>
@@ -78,6 +81,7 @@ public class FileMapperRegexInferenceTests
 
         fixture.FileMappingRepository.Verify(repository => repository.ReplaceForAnimationInfoAsync(
             fixture.AnimationInfoId,
+            ExpectedStateVersion,
             "test-store",
             "/downloads/anime",
             It.Is<IReadOnlyList<FileMapping>>(mappings =>
@@ -257,6 +261,7 @@ public class FileMapperRegexInferenceTests
             CancellationToken.None), Times.Once);
         fixture.FileMappingRepository.Verify(repository => repository.ReplaceForAnimationInfoAsync(
             It.IsAny<Guid>(),
+            It.IsAny<long>(),
             It.IsAny<string>(),
             It.IsAny<string>(),
             It.IsAny<IReadOnlyList<FileMapping>>(),
@@ -283,6 +288,7 @@ public class FileMapperRegexInferenceTests
         Assert.IsFalse(result);
         fixture.FileMappingRepository.Verify(repository => repository.ReplaceForAnimationInfoAsync(
             It.IsAny<Guid>(),
+            It.IsAny<long>(),
             It.IsAny<string>(),
             It.IsAny<string>(),
             It.IsAny<IReadOnlyList<FileMapping>>(),
@@ -320,6 +326,7 @@ public class FileMapperRegexInferenceTests
         Assert.IsTrue(result);
         fixture.FileMappingRepository.Verify(repository => repository.ReplaceForAnimationInfoAsync(
             fixture.AnimationInfoId,
+            ExpectedStateVersion,
             "test-store",
             "/downloads/anime",
             It.Is<IReadOnlyList<FileMapping>>(mappings =>
@@ -344,6 +351,7 @@ public class FileMapperRegexInferenceTests
         fixture.FileMappingRepository
             .Setup(repository => repository.ReplaceForAnimationInfoAsync(
                 fixture.AnimationInfoId,
+                ExpectedStateVersion,
                 "test-store",
                 "/downloads/anime",
                 It.IsAny<IReadOnlyList<FileMapping>>(),
@@ -355,6 +363,37 @@ public class FileMapperRegexInferenceTests
             CancellationToken.None);
 
         Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public async Task PreviewDownloadAsync_RegexMiss_DoesNotCallAiOrReplaceMappings()
+    {
+        var fixture = CreateFixture();
+        fixture.RuleRepository
+            .Setup(repository => repository.GetForAnimationAsync(
+                fixture.AnimationId,
+                CancellationToken.None))
+            .ReturnsAsync(Array.Empty<FileNameRegexRule>());
+
+        var preview = await fixture.Mapper.PreviewDownloadAsync(
+            fixture.Info,
+            CancellationToken.None);
+
+        Assert.IsNotNull(preview);
+        Assert.AreEqual(2, preview.Mappings.Count);
+        Assert.IsTrue(preview.Mappings.All(mapping =>
+            mapping.VirtualPath.StartsWith("/unknown/", StringComparison.Ordinal)));
+        CollectionAssert.Contains(preview.Warnings.ToList(), "unresolvedFiles");
+        fixture.InferenceEngine.Verify(engine => engine.InferFileNamesAsync(
+            It.IsAny<FileNameInferenceRequest>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        fixture.FileMappingRepository.Verify(repository => repository.ReplaceForAnimationInfoAsync(
+            It.IsAny<Guid>(),
+            It.IsAny<long>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<IReadOnlyList<FileMapping>>(),
+            It.IsAny<CancellationToken>()), Times.Never);
     }
 
     private static Fixture CreateFixture()
@@ -383,7 +422,8 @@ public class FileMapperRegexInferenceTests
             group,
             animation,
             true,
-            0);
+            0,
+            StateVersion: ExpectedStateVersion);
 
         var animationInfoRepository = new Mock<IAnimationInfoRepository>();
         animationInfoRepository
@@ -401,6 +441,7 @@ public class FileMapperRegexInferenceTests
         fileMappingRepository
             .Setup(repository => repository.ReplaceForAnimationInfoAsync(
                 It.IsAny<Guid>(),
+                It.IsAny<long>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<IReadOnlyList<FileMapping>>(),
@@ -430,6 +471,7 @@ public class FileMapperRegexInferenceTests
         return new Fixture(
             animationInfoId,
             animationId,
+            info,
             mapper,
             fileMappingRepository,
             ruleRepository,
@@ -439,6 +481,7 @@ public class FileMapperRegexInferenceTests
     private sealed record Fixture(
         Guid AnimationInfoId,
         Guid AnimationId,
+        AnimationInfo Info,
         FileMapper Mapper,
         Mock<IFileMappingRepository> FileMappingRepository,
         Mock<IFileNameRegexRuleRepository> RuleRepository,

--- a/SecondDimensionWatcherReDive.Test/InferAnimationMetadataTests.cs
+++ b/SecondDimensionWatcherReDive.Test/InferAnimationMetadataTests.cs
@@ -30,6 +30,12 @@ public class InferAnimationMetadataTests
         _mockAnimationGroupRepo = new Mock<IAnimationGroupRepository>();
         _mockInferenceEngine = new Mock<IInferenceEngine>();
         _mockFileMapper = new Mock<IFileMapper>();
+        _mockAnimationInfoRepo
+            .Setup(repository => repository.TryUpdateAsync(
+                It.IsAny<AnimationInfo>(),
+                It.IsAny<long>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         var mockScopeFactory = new Mock<IServiceScopeFactory>();
 
@@ -53,12 +59,15 @@ public class InferAnimationMetadataTests
         Guid id,
         string title = "Test Title",
         string description = "Test Description",
-        int aiRetryCount = 0) =>
+        int aiRetryCount = 0,
+        bool isDownloadFinished = false,
+        long stateVersion = 11) =>
         new(id, title, description, DateTimeOffset.Now,
             "", "", Array.Empty<byte>(), "",
-            false, default, default, false,
+            false, default, default, isDownloadFinished,
             null, null, null, null, null, null,
-            false, aiRetryCount);
+            false, aiRetryCount,
+            StateVersion: stateVersion);
 
     private Task InvokeProcessItem(AnimationInfo item, CancellationToken cancellationToken)
     {
@@ -75,7 +84,7 @@ public class InferAnimationMetadataTests
     }
 
     [TestMethod]
-    public async Task ProcessItem_InferenceReturnsNull_MarksProcessed()
+    public async Task ProcessItem_InferenceReturnsNull_LeavesPendingAndIncrementsRetry()
     {
         var item = CreateTestInfo(Guid.NewGuid());
 
@@ -86,9 +95,18 @@ public class InferAnimationMetadataTests
         await InvokeProcessItem(item, CancellationToken.None);
 
         _mockAnimationInfoRepo.Verify(
-            r => r.UpdateAsync(
-                It.Is<AnimationInfo>(i => i.IsAiProcessed),
+            r => r.TryUpdateAsync(
+                It.Is<AnimationInfo>(i =>
+                    !i.IsAiProcessed &&
+                    i.AiRetryCount == 1 &&
+                    i.MetadataStatus == MetadataReviewStatus.Pending &&
+                    i.MetadataConfidence == null &&
+                    i.MetadataLastError != null),
+                item.StateVersion,
                 It.IsAny<CancellationToken>()), Times.Once);
+        _mockAnimationInfoRepo.Verify(
+            r => r.UpdateAsync(It.IsAny<AnimationInfo>(), It.IsAny<CancellationToken>()),
+            Times.Never);
         _mockAnimationRepo.Verify(
             r => r.AddAsync(It.IsAny<Animation>(), It.IsAny<CancellationToken>()), Times.Never);
         _mockAnimationGroupRepo.Verify(
@@ -96,13 +114,13 @@ public class InferAnimationMetadataTests
     }
 
     [TestMethod]
-    public async Task ProcessItem_WithResult_CreatesAnimationAndGroup()
+    public async Task ProcessItem_WithHighConfidenceResult_CreatesAnimationAndGroupAndMarksIdentified()
     {
         var item = CreateTestInfo(Guid.NewGuid(),
             title: "[SubGroup] Anime Title - 01 [1080p]",
             description: "Episode description");
 
-        var result = new InferenceResult("12345", "SubGroup", 1, 1);
+        var result = new InferenceResult("12345", "SubGroup", 1, 1, 0.91);
 
         _mockInferenceEngine
             .Setup(e => e.InferAsync(item.Title, item.Description, It.IsAny<CancellationToken>()))
@@ -121,13 +139,17 @@ public class InferAnimationMetadataTests
         await InvokeProcessItem(item, CancellationToken.None);
 
         _mockAnimationInfoRepo.Verify(
-            r => r.UpdateAsync(
+            r => r.TryUpdateAsync(
                 It.Is<AnimationInfo>(i =>
                     i.IsAiProcessed &&
+                    i.MetadataStatus == MetadataReviewStatus.Identified &&
+                    i.MetadataConfidence == 0.91 &&
+                    i.MetadataLastError == null &&
                     i.Season == 1 &&
                     i.Episode == 1 &&
                     i.Animation != null && i.Animation.TmdbId == "12345" &&
                     i.Group != null && i.Group.Name == "SubGroup"),
+                item.StateVersion,
                 It.IsAny<CancellationToken>()), Times.Once);
 
         _mockAnimationRepo.Verify(
@@ -144,11 +166,33 @@ public class InferAnimationMetadataTests
     }
 
     [TestMethod]
-    public async Task ProcessItem_ExceptionIncrementsRetryCount()
+    public async Task ProcessItem_WithLowConfidenceResult_MarksLowConfidence()
+    {
+        var item = CreateTestInfo(Guid.NewGuid());
+        _mockInferenceEngine
+            .Setup(e => e.InferAsync(item.Title, item.Description, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new InferenceResult(null, null, 2, 4, 0.42));
+
+        await InvokeProcessItem(item, CancellationToken.None);
+
+        _mockAnimationInfoRepo.Verify(repository => repository.TryUpdateAsync(
+            It.Is<AnimationInfo>(updated =>
+                updated.IsAiProcessed &&
+                updated.MetadataStatus == MetadataReviewStatus.LowConfidence &&
+                updated.MetadataConfidence == 0.42 &&
+                updated.Season == 2 &&
+                updated.Episode == 4),
+            item.StateVersion,
+            CancellationToken.None), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task ProcessItem_ThirdFailure_MarksFailed()
     {
         var item = CreateTestInfo(Guid.NewGuid(),
             title: "Failing Title",
-            description: "Failing Description");
+            description: "Failing Description",
+            aiRetryCount: 2);
 
         _mockInferenceEngine
             .Setup(e => e.InferAsync(item.Title, item.Description, It.IsAny<CancellationToken>()))
@@ -157,8 +201,45 @@ public class InferAnimationMetadataTests
         await InvokeProcessItem(item, CancellationToken.None);
 
         _mockAnimationInfoRepo.Verify(
-            r => r.UpdateAsync(
-                It.Is<AnimationInfo>(i => i.AiRetryCount == 1 && !i.IsAiProcessed),
+            r => r.TryUpdateAsync(
+                It.Is<AnimationInfo>(i =>
+                    i.AiRetryCount == 3 &&
+                    !i.IsAiProcessed &&
+                    i.MetadataStatus == MetadataReviewStatus.Failed &&
+                    i.MetadataLastError == "AI service unavailable"),
+                item.StateVersion,
                 It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task ProcessItem_StaleSuccessfulInference_DoesNotRemapDownloadedFiles()
+    {
+        var item = CreateTestInfo(
+            Guid.NewGuid(),
+            isDownloadFinished: true,
+            stateVersion: 42);
+        _mockInferenceEngine
+            .Setup(engine => engine.InferAsync(
+                item.Title,
+                item.Description,
+                CancellationToken.None))
+            .ReturnsAsync(new InferenceResult(null, null, 1, 1, 0.95));
+        _mockAnimationInfoRepo
+            .Setup(repository => repository.TryUpdateAsync(
+                It.IsAny<AnimationInfo>(),
+                item.StateVersion,
+                CancellationToken.None))
+            .ReturnsAsync(false);
+
+        await InvokeProcessItem(item, CancellationToken.None);
+
+        _mockAnimationInfoRepo.Verify(repository => repository.TryUpdateAsync(
+            It.Is<AnimationInfo>(updated =>
+                updated.MetadataStatus == MetadataReviewStatus.Identified),
+            item.StateVersion,
+            CancellationToken.None), Times.Once);
+        _mockFileMapper.Verify(mapper => mapper.MapDownloadAsync(
+            It.IsAny<Guid>(),
+            It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/SecondDimensionWatcherReDive.Test/MetadataReviewServiceTests.cs
+++ b/SecondDimensionWatcherReDive.Test/MetadataReviewServiceTests.cs
@@ -1,0 +1,398 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using SecondDimensionWatcherReDive.Framework.DataRepository;
+using SecondDimensionWatcherReDive.Inference.AI.Tools;
+using SecondDimensionWatcherReDive.Utils.FileStore;
+using SecondDimensionWatcherReDive.Utils.MetadataReview;
+using TMDbLib.Client;
+
+namespace SecondDimensionWatcherReDive.Test;
+
+[TestClass]
+public class MetadataReviewServiceTests
+{
+    private Mock<IAnimationInfoRepository> _animationInfoRepository = null!;
+    private Mock<IAnimationRepository> _animationRepository = null!;
+    private Mock<IAnimationGroupRepository> _animationGroupRepository = null!;
+    private Mock<IFileMappingRepository> _fileMappingRepository = null!;
+    private Mock<IMetadataReviewRepository> _metadataReviewRepository = null!;
+    private Mock<IFileMapper> _fileMapper = null!;
+    private MetadataReviewService _service = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _animationInfoRepository = new Mock<IAnimationInfoRepository>();
+        _animationRepository = new Mock<IAnimationRepository>();
+        _animationGroupRepository = new Mock<IAnimationGroupRepository>();
+        _fileMappingRepository = new Mock<IFileMappingRepository>();
+        _metadataReviewRepository = new Mock<IMetadataReviewRepository>();
+        _fileMapper = new Mock<IFileMapper>();
+
+        var tmdbClient = new TMDbClient("fake-key", false, "127.0.0.1:1");
+        var tmdbTool = new TmdbTool(tmdbClient, Mock.Of<ILogger<TmdbTool>>());
+        _service = new MetadataReviewService(
+            _animationInfoRepository.Object,
+            _animationRepository.Object,
+            _animationGroupRepository.Object,
+            _fileMappingRepository.Object,
+            _metadataReviewRepository.Object,
+            _fileMapper.Object,
+            tmdbTool);
+    }
+
+    [TestMethod]
+    public async Task PreviewAsync_InvalidCorrection_ReportsSpecificValidationCode()
+    {
+        var item = CreateInfo(stateVersion: 5);
+        _animationInfoRepository
+            .Setup(repository => repository.FindByIdWithAnimationAsync(
+                item.Id,
+                CancellationToken.None))
+            .ReturnsAsync(item);
+        var cases = new (MetadataReviewCorrection Correction, string Code)[]
+        {
+            (new MetadataReviewCorrection("not-a-number", 1, 1, null), "invalidTmdbId"),
+            (new MetadataReviewCorrection("123", null, 1, null), "seasonRequired"),
+            (new MetadataReviewCorrection("123", -1, 1, null), "invalidSeason"),
+            (new MetadataReviewCorrection("123", 1, -1, null), "invalidEpisode"),
+            (new MetadataReviewCorrection("123", 1, 1, new string('x', 201)), "groupNameTooLong")
+        };
+
+        foreach (var (correction, expectedCode) in cases)
+        {
+            try
+            {
+                await _service.PreviewAsync(
+                    item.Id,
+                    item.StateVersion,
+                    correction,
+                    CancellationToken.None);
+                Assert.Fail($"Expected validation error {expectedCode}.");
+            }
+            catch (MetadataReviewValidationException exception)
+            {
+                Assert.AreEqual(expectedCode, exception.Code);
+            }
+        }
+
+        _animationRepository.Verify(repository => repository.FindByTmdbIdAsync(
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        _fileMapper.Verify(mapper => mapper.PreviewDownloadAsync(
+            It.IsAny<AnimationInfo>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task PreviewAsync_StaleRevision_RejectsBeforeResolvingMetadata()
+    {
+        var item = CreateInfo(stateVersion: 8);
+        _animationInfoRepository
+            .Setup(repository => repository.FindByIdWithAnimationAsync(
+                item.Id,
+                CancellationToken.None))
+            .ReturnsAsync(item);
+
+        var exception = await Assert.ThrowsExactlyAsync<MetadataReviewConflictException>(() =>
+            _service.PreviewAsync(
+                item.Id,
+                expectedRevision: 7,
+                new MetadataReviewCorrection("123", 1, 1, "Group"),
+                CancellationToken.None));
+
+        Assert.AreEqual("staleRevision", exception.Code);
+        _animationRepository.Verify(repository => repository.FindByTmdbIdAsync(
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        _fileMapper.Verify(mapper => mapper.PreviewDownloadAsync(
+            It.IsAny<AnimationInfo>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        _metadataReviewRepository.Verify(repository => repository.SavePreviewAsync(
+            It.IsAny<MetadataReviewPreviewDraft>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task PreviewAsync_DownloadedItem_PlansPathsAndPersistsVersionedDraft()
+    {
+        var item = CreateInfo(stateVersion: 12, isDownloadFinished: true);
+        var targetAnimation = new Animation(
+            Guid.NewGuid(),
+            "456",
+            "Target Anime",
+            "Target Original",
+            "/target.jpg");
+        var targetGroup = new AnimationGroup(Guid.NewGuid(), "Target Group");
+        var currentMapping = new FileMapping(
+            Guid.NewGuid(),
+            item.Id,
+            "/unknown/Anime - 03.mkv",
+            "/downloads/anime/Anime - 03.mkv",
+            "test-store");
+        var proposedMapping = currentMapping with
+        {
+            Id = Guid.NewGuid(),
+            VirtualPath = "/Target Anime/Target Group/Target Anime S02E03 (2).mkv"
+        };
+        AnimationInfo? plannedInfo = null;
+        MetadataReviewPreviewDraft? savedDraft = null;
+
+        _animationInfoRepository
+            .Setup(repository => repository.FindByIdWithAnimationAsync(
+                item.Id,
+                CancellationToken.None))
+            .ReturnsAsync(item);
+        _animationRepository
+            .Setup(repository => repository.FindByTmdbIdAsync(
+                "456",
+                CancellationToken.None))
+            .ReturnsAsync(targetAnimation);
+        _animationGroupRepository
+            .Setup(repository => repository.FindByNameAsync(
+                "Target Group",
+                CancellationToken.None))
+            .ReturnsAsync(targetGroup);
+        _fileMappingRepository
+            .Setup(repository => repository.GetForAnimationInfoAsync(
+                item.Id,
+                CancellationToken.None))
+            .ReturnsAsync([currentMapping]);
+        _fileMapper
+            .Setup(mapper => mapper.PreviewDownloadAsync(
+                It.IsAny<AnimationInfo>(),
+                CancellationToken.None))
+            .Callback<AnimationInfo, CancellationToken>((info, _) => plannedInfo = info)
+            .ReturnsAsync(new FileMappingPreview(
+                [proposedMapping],
+                ["collisionAdjusted"]));
+        _metadataReviewRepository
+            .Setup(repository => repository.SavePreviewAsync(
+                It.IsAny<MetadataReviewPreviewDraft>(),
+                CancellationToken.None))
+            .Callback<MetadataReviewPreviewDraft, CancellationToken>((draft, _) => savedDraft = draft)
+            .Returns(Task.CompletedTask);
+
+        var result = await _service.PreviewAsync(
+            item.Id,
+            item.StateVersion,
+            new MetadataReviewCorrection(" 456 ", 2, 3, " Target Group "),
+            CancellationToken.None);
+
+        Assert.IsNotNull(plannedInfo);
+        Assert.AreEqual(targetAnimation, plannedInfo.Animation);
+        Assert.AreEqual(targetGroup, plannedInfo.Group);
+        Assert.AreEqual(2, plannedInfo.Season);
+        Assert.AreEqual(3, plannedInfo.Episode);
+        Assert.AreEqual(MetadataReviewStatus.Reviewed, plannedInfo.MetadataStatus);
+        Assert.AreEqual(1d, plannedInfo.MetadataConfidence);
+        Assert.AreEqual(item.StateVersion, result.BaseRevision);
+        Assert.IsTrue(result.CanApply);
+        CollectionAssert.Contains(result.Warnings.ToList(), "collisionAdjusted");
+        Assert.AreEqual(1, result.PathChanges.Count);
+        Assert.AreEqual("moved", result.PathChanges[0].ChangeKind);
+        Assert.IsTrue(result.PathChanges[0].CollisionAdjusted);
+
+        Assert.IsNotNull(savedDraft);
+        Assert.AreEqual(result.PreviewId, savedDraft.Id);
+        Assert.AreEqual(item.StateVersion, savedDraft.BaseVersion);
+        Assert.AreEqual(item.FileStore, savedDraft.BaseFileStore);
+        Assert.AreEqual(item.StorePath, savedDraft.BaseStorePath);
+        Assert.AreEqual(targetAnimation, savedDraft.ProposedAnimation);
+        Assert.AreEqual("Target Group", savedDraft.ProposedGroupName);
+        Assert.AreEqual(proposedMapping, savedDraft.ProposedMappings.Single());
+    }
+
+    [TestMethod]
+    public async Task ApplyAsync_Success_ReturnsRevisionAndPathDiff()
+    {
+        var operationId = Guid.NewGuid();
+        var animationInfoId = Guid.NewGuid();
+        var appliedAt = DateTimeOffset.UtcNow;
+        var before = new FileMapping(
+            Guid.NewGuid(),
+            animationInfoId,
+            "/unknown/episode.mkv",
+            "/store/episode.mkv",
+            "test-store");
+        var after = before with
+        {
+            Id = Guid.NewGuid(),
+            VirtualPath = "/Anime/Group/Anime S01E01.mkv"
+        };
+        _metadataReviewRepository
+            .Setup(repository => repository.ApplyPreviewAsync(
+                operationId,
+                animationInfoId,
+                CancellationToken.None))
+            .ReturnsAsync(new MetadataReviewMutationResult(
+                MetadataReviewMutationOutcome.Success,
+                operationId,
+                animationInfoId,
+                14,
+                appliedAt,
+                [before],
+                [after]));
+
+        var result = await _service.ApplyAsync(
+            animationInfoId,
+            operationId,
+            CancellationToken.None);
+
+        Assert.AreEqual(operationId, result.OperationId);
+        Assert.AreEqual(14, result.Revision);
+        Assert.AreEqual(appliedAt, result.AppliedAt);
+        Assert.IsTrue(result.CanUndo);
+        Assert.AreEqual(1, result.PathChanges.Count);
+        Assert.AreEqual("moved", result.PathChanges[0].ChangeKind);
+        Assert.AreEqual(before.VirtualPath, result.PathChanges[0].CurrentVirtualPath);
+        Assert.AreEqual(after.VirtualPath, result.PathChanges[0].ProposedVirtualPath);
+    }
+
+    [TestMethod]
+    [DataRow(MetadataReviewMutationOutcome.NotFound, "operationNotFound")]
+    [DataRow(MetadataReviewMutationOutcome.Expired, "previewExpired")]
+    [DataRow(MetadataReviewMutationOutcome.Conflict, "stalePreview")]
+    public async Task ApplyAsync_NonSuccessOutcome_ThrowsCodedServiceError(
+        MetadataReviewMutationOutcome outcome,
+        string expectedCode)
+    {
+        var operationId = Guid.NewGuid();
+        var animationInfoId = Guid.NewGuid();
+        _metadataReviewRepository
+            .Setup(repository => repository.ApplyPreviewAsync(
+                operationId,
+                animationInfoId,
+                CancellationToken.None))
+            .ReturnsAsync(new MetadataReviewMutationResult(
+                outcome,
+                operationId,
+                animationInfoId,
+                null,
+                null,
+                [],
+                []));
+
+        MetadataReviewServiceException? exception = null;
+        try
+        {
+            await _service.ApplyAsync(
+                animationInfoId,
+                operationId,
+                CancellationToken.None);
+        }
+        catch (MetadataReviewServiceException caught)
+        {
+            exception = caught;
+        }
+
+        Assert.IsNotNull(exception);
+        Assert.AreEqual(expectedCode, exception.Code);
+    }
+
+    [TestMethod]
+    public async Task UndoAsync_Success_ReturnsRestoredPathsAndCannotUndoAgain()
+    {
+        var operationId = Guid.NewGuid();
+        var animationInfoId = Guid.NewGuid();
+        var undoneAt = DateTimeOffset.UtcNow;
+        var applied = new FileMapping(
+            Guid.NewGuid(),
+            animationInfoId,
+            "/Anime/Group/Anime S01E01.mkv",
+            "/store/episode.mkv",
+            "test-store");
+        var restored = applied with
+        {
+            Id = Guid.NewGuid(),
+            VirtualPath = "/unknown/episode.mkv"
+        };
+        _metadataReviewRepository
+            .Setup(repository => repository.UndoAsync(
+                operationId,
+                14,
+                CancellationToken.None))
+            .ReturnsAsync(new MetadataReviewMutationResult(
+                MetadataReviewMutationOutcome.Success,
+                operationId,
+                animationInfoId,
+                15,
+                undoneAt,
+                [applied],
+                [restored]));
+
+        var result = await _service.UndoAsync(
+            operationId,
+            expectedRevision: 14,
+            CancellationToken.None);
+
+        Assert.AreEqual(15, result.Revision);
+        Assert.IsFalse(result.CanUndo);
+        Assert.AreEqual("moved", result.PathChanges.Single().ChangeKind);
+        Assert.AreEqual(applied.VirtualPath, result.PathChanges.Single().CurrentVirtualPath);
+        Assert.AreEqual(restored.VirtualPath, result.PathChanges.Single().ProposedVirtualPath);
+    }
+
+    [TestMethod]
+    public async Task UndoAsync_Conflict_ReportsUndoConflict()
+    {
+        var operationId = Guid.NewGuid();
+        _metadataReviewRepository
+            .Setup(repository => repository.UndoAsync(
+                operationId,
+                14,
+                CancellationToken.None))
+            .ReturnsAsync(new MetadataReviewMutationResult(
+                MetadataReviewMutationOutcome.Conflict,
+                operationId,
+                null,
+                null,
+                null,
+                [],
+                []));
+
+        var exception = await Assert.ThrowsExactlyAsync<MetadataReviewConflictException>(() =>
+            _service.UndoAsync(
+                operationId,
+                expectedRevision: 14,
+                CancellationToken.None));
+
+        Assert.AreEqual("undoConflict", exception.Code);
+    }
+
+    private static AnimationInfo CreateInfo(
+        long stateVersion,
+        bool isDownloadFinished = false)
+    {
+        var currentAnimation = new Animation(
+            Guid.NewGuid(),
+            "123",
+            "Current Anime",
+            "Current Original",
+            null);
+        return new AnimationInfo(
+            Guid.NewGuid(),
+            "Release title",
+            "Current description",
+            DateTimeOffset.UtcNow,
+            "https://example.test/release.torrent",
+            "torrent",
+            [],
+            "hash",
+            isDownloadFinished,
+            default,
+            default,
+            isDownloadFinished,
+            isDownloadFinished ? "test-store" : null,
+            isDownloadFinished ? "/downloads/anime" : null,
+            1,
+            1,
+            new AnimationGroup(Guid.NewGuid(), "Current Group"),
+            currentAnimation,
+            true,
+            0,
+            MetadataStatus: MetadataReviewStatus.LowConfidence,
+            MetadataConfidence: 0.4,
+            StateVersion: stateVersion);
+    }
+}

--- a/SecondDimensionWatcherReDive.Test/TmdbRegistrationTests.cs
+++ b/SecondDimensionWatcherReDive.Test/TmdbRegistrationTests.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SecondDimensionWatcherReDive.Inference.AI;
+using SecondDimensionWatcherReDive.Inference.AI.Tools;
+
+namespace SecondDimensionWatcherReDive.Test;
+
+[TestClass]
+public class TmdbRegistrationTests
+{
+    [TestMethod]
+    public void AddTmdbMetadata_WithoutApiKey_StillResolvesTool()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddTmdbMetadata(new ConfigurationBuilder().Build());
+
+        using var provider = services.BuildServiceProvider();
+        var tool = provider.GetRequiredService<TmdbTool>();
+
+        Assert.IsFalse(tool.IsConfigured);
+    }
+}

--- a/SecondDimensionWatcherReDive/Controllers/AnimationInfoController.cs
+++ b/SecondDimensionWatcherReDive/Controllers/AnimationInfoController.cs
@@ -175,7 +175,15 @@ internal class AnimationInfoController(
         if (info is null)
             return NotFound();
 
-        var updated = info with { IsAiProcessed = false, AiRetryCount = 0 };
+        var updated = info with
+        {
+            IsAiProcessed = false,
+            AiRetryCount = 0,
+            MetadataStatus = MetadataReviewStatus.Pending,
+            MetadataConfidence = null,
+            MetadataLastError = null,
+            MetadataReviewedAt = null
+        };
         await animationInfoRepository.UpdateAsync(updated, cancellationToken);
         return Ok();
     }

--- a/SecondDimensionWatcherReDive/Controllers/External/AppJsonSerializerContext.cs
+++ b/SecondDimensionWatcherReDive/Controllers/External/AppJsonSerializerContext.cs
@@ -31,4 +31,11 @@ namespace SecondDimensionWatcherReDive.Controllers.External;
 [JsonSerializable(typeof(CreateWebDavTokenResponse))]
 [JsonSerializable(typeof(VfsEntry))]
 [JsonSerializable(typeof(VfsEntry[]))]
+[JsonSerializable(typeof(MetadataReviewQueueResponse))]
+[JsonSerializable(typeof(MetadataReviewPreviewRequest))]
+[JsonSerializable(typeof(MetadataReviewApplyRequest))]
+[JsonSerializable(typeof(MetadataReviewUndoRequest))]
+[JsonSerializable(typeof(MetadataReviewPreviewResponse))]
+[JsonSerializable(typeof(MetadataReviewMutationResponse))]
+[JsonSerializable(typeof(MetadataReviewError))]
 internal partial class AppJsonSerializerContext : JsonSerializerContext;

--- a/SecondDimensionWatcherReDive/Controllers/External/MetadataReview.cs
+++ b/SecondDimensionWatcherReDive/Controllers/External/MetadataReview.cs
@@ -1,0 +1,85 @@
+namespace SecondDimensionWatcherReDive.Controllers.External;
+
+internal sealed record MetadataReviewQueueResponse(
+    IReadOnlyList<MetadataReviewItem> Data,
+    int TotalItems,
+    MetadataReviewCounts Counts,
+    IReadOnlyList<MetadataReviewRecentOperation> RecentOperations);
+
+internal sealed record MetadataReviewCounts(
+    int Pending,
+    int LowConfidence,
+    int Failed);
+
+internal sealed record MetadataReviewItem(
+    Guid Id,
+    string Title,
+    string Description,
+    DateTimeOffset PublishTime,
+    string ReviewStatus,
+    double? Confidence,
+    string? FailureReason,
+    int AiRetryCount,
+    MetadataReviewMetadata Metadata,
+    bool IsDownloadFinished,
+    int MappedFileCount,
+    long Revision,
+    Guid? CurrentOperationId,
+    DateTimeOffset? CurrentOperationAppliedAt,
+    bool CanUndo);
+
+internal sealed record MetadataReviewMetadata(
+    string? TmdbId,
+    string? Name,
+    string? OriginalName,
+    string? PosterPath,
+    int? Season,
+    int? Episode,
+    string? GroupName);
+
+internal sealed record MetadataReviewRecentOperation(
+    Guid OperationId,
+    Guid ItemId,
+    string Title,
+    DateTimeOffset AppliedAt,
+    long Revision,
+    bool CanUndo);
+
+internal sealed record MetadataReviewDraft(
+    string? TmdbId,
+    int? Season,
+    int? Episode,
+    string? GroupName);
+
+internal sealed record MetadataReviewPreviewRequest(
+    long ExpectedRevision,
+    MetadataReviewDraft Metadata);
+
+internal sealed record MetadataReviewApplyRequest(Guid PreviewId);
+
+internal sealed record MetadataReviewUndoRequest(long ExpectedRevision);
+
+internal sealed record MetadataReviewPreviewResponse(
+    Guid PreviewId,
+    long BaseRevision,
+    MetadataReviewMetadata ResolvedMetadata,
+    IReadOnlyList<MetadataReviewPathChange> PathChanges,
+    IReadOnlyList<string> Warnings,
+    bool CanApply,
+    DateTimeOffset ExpiresAt);
+
+internal sealed record MetadataReviewPathChange(
+    string FileName,
+    string? CurrentVirtualPath,
+    string? ProposedVirtualPath,
+    string ChangeKind,
+    bool CollisionAdjusted);
+
+internal sealed record MetadataReviewMutationResponse(
+    Guid OperationId,
+    long Revision,
+    IReadOnlyList<MetadataReviewPathChange> PathChanges,
+    DateTimeOffset AppliedAt,
+    bool CanUndo);
+
+internal sealed record MetadataReviewError(string Code, string Message);

--- a/SecondDimensionWatcherReDive/Controllers/MetadataReviewController.cs
+++ b/SecondDimensionWatcherReDive/Controllers/MetadataReviewController.cs
@@ -1,0 +1,238 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SecondDimensionWatcherReDive.Framework.DataRepository;
+using SecondDimensionWatcherReDive.Utils.MetadataReview;
+using External = SecondDimensionWatcherReDive.Controllers.External;
+
+namespace SecondDimensionWatcherReDive.Controllers;
+
+[ApiController]
+[Route("api/metadata-review")]
+[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+internal sealed class MetadataReviewController(
+    IMetadataReviewRepository metadataReviewRepository,
+    IMetadataReviewService metadataReviewService) : ControllerBase
+{
+    [HttpGet]
+    public async Task<IActionResult> GetAsync(
+        [FromQuery] string status = "pending",
+        [FromQuery] int skip = 0,
+        [FromQuery] int take = 20,
+        CancellationToken cancellationToken = default)
+    {
+        if (!TryParseQueueStatus(status, out var parsedStatus))
+            return BadRequest(new External.MetadataReviewError(
+                "invalidStatus",
+                "Status must be pending, lowConfidence, or failed."));
+        if (skip < 0 || take is < 1 or > 100)
+            return BadRequest(new External.MetadataReviewError(
+                "invalidPagination",
+                "Skip must be non-negative and take must be between 1 and 100."));
+
+        var page = await metadataReviewRepository.GetQueueAsync(
+            parsedStatus,
+            skip,
+            take,
+            cancellationToken);
+        return Ok(ToExternal(page));
+    }
+
+    [HttpPost("{id:guid}/preview")]
+    public async Task<IActionResult> PreviewAsync(
+        [FromRoute] Guid id,
+        [FromBody] External.MetadataReviewPreviewRequest request,
+        CancellationToken cancellationToken)
+    {
+        if (request.Metadata is null)
+            return UnprocessableEntity(new External.MetadataReviewError(
+                "metadataRequired",
+                "Metadata values are required."));
+
+        try
+        {
+            var result = await metadataReviewService.PreviewAsync(
+                id,
+                request.ExpectedRevision,
+                new MetadataReviewCorrection(
+                    request.Metadata.TmdbId,
+                    request.Metadata.Season,
+                    request.Metadata.Episode,
+                    request.Metadata.GroupName),
+                cancellationToken);
+            return Ok(ToExternal(result));
+        }
+        catch (MetadataReviewServiceException ex)
+        {
+            return ToErrorResult(ex);
+        }
+    }
+
+    [HttpPost("{id:guid}/apply")]
+    public async Task<IActionResult> ApplyAsync(
+        [FromRoute] Guid id,
+        [FromBody] External.MetadataReviewApplyRequest request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await metadataReviewService.ApplyAsync(
+                id,
+                request.PreviewId,
+                cancellationToken);
+            return Ok(ToExternal(result));
+        }
+        catch (MetadataReviewServiceException ex)
+        {
+            return ToErrorResult(ex);
+        }
+    }
+
+    [HttpPost("remaps/{operationId:guid}/undo")]
+    public async Task<IActionResult> UndoAsync(
+        [FromRoute] Guid operationId,
+        [FromBody] External.MetadataReviewUndoRequest request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await metadataReviewService.UndoAsync(
+                operationId,
+                request.ExpectedRevision,
+                cancellationToken);
+            return Ok(ToExternal(result));
+        }
+        catch (MetadataReviewServiceException ex)
+        {
+            return ToErrorResult(ex);
+        }
+    }
+
+    private IActionResult ToErrorResult(MetadataReviewServiceException exception)
+    {
+        var error = new External.MetadataReviewError(exception.Code, exception.Message);
+        return exception switch
+        {
+            MetadataReviewNotFoundException => NotFound(error),
+            MetadataReviewConflictException => Conflict(error),
+            MetadataReviewValidationException => UnprocessableEntity(error),
+            MetadataReviewUnavailableException => StatusCode(
+                StatusCodes.Status503ServiceUnavailable,
+                error),
+            _ => StatusCode(StatusCodes.Status500InternalServerError, error)
+        };
+    }
+
+    private static External.MetadataReviewQueueResponse ToExternal(MetadataReviewQueuePage page) =>
+        new(
+            page.Data.Select(ToExternal).ToList(),
+            page.TotalCount,
+            new External.MetadataReviewCounts(
+                page.Counts.Pending,
+                page.Counts.LowConfidence,
+                page.Counts.Failed),
+            page.RecentOperations.Select(operation =>
+                new External.MetadataReviewRecentOperation(
+                    operation.OperationId,
+                    operation.AnimationInfoId,
+                    operation.Title,
+                    operation.AppliedAt,
+                    operation.Revision,
+                    operation.CanUndo)).ToList());
+
+    private static External.MetadataReviewItem ToExternal(MetadataReviewQueueItem item)
+    {
+        var info = item.Info;
+        return new External.MetadataReviewItem(
+            info.Id,
+            info.Title,
+            info.Description,
+            info.PublishTime,
+            ToExternalStatus(info.MetadataStatus),
+            info.MetadataConfidence,
+            info.MetadataLastError,
+            info.AiRetryCount,
+            new External.MetadataReviewMetadata(
+                info.Animation?.TmdbId,
+                info.Animation?.Name,
+                info.Animation?.OriginalName,
+                info.Animation?.PosterPath,
+                info.Season,
+                info.Episode,
+                info.Group?.Name),
+            info.IsDownloadFinished,
+            item.MappedFileCount,
+            info.StateVersion,
+            item.CurrentOperationId,
+            item.CurrentOperationAppliedAt,
+            item.CanUndo);
+    }
+
+    private static External.MetadataReviewPreviewResponse ToExternal(
+        MetadataReviewPreviewResult result) =>
+        new(
+            result.PreviewId,
+            result.BaseRevision,
+            new External.MetadataReviewMetadata(
+                result.ResolvedMetadata.TmdbId,
+                result.ResolvedMetadata.Name,
+                result.ResolvedMetadata.OriginalName,
+                result.ResolvedMetadata.PosterPath,
+                result.ResolvedMetadata.Season,
+                result.ResolvedMetadata.Episode,
+                result.ResolvedMetadata.GroupName),
+            result.PathChanges.Select(ToExternal).ToList(),
+            result.Warnings,
+            result.CanApply,
+            result.ExpiresAt);
+
+    private static External.MetadataReviewMutationResponse ToExternal(
+        MetadataReviewChangeResult result) =>
+        new(
+            result.OperationId,
+            result.Revision,
+            result.PathChanges.Select(ToExternal).ToList(),
+            result.AppliedAt,
+            result.CanUndo);
+
+    private static External.MetadataReviewPathChange ToExternal(MetadataReviewPathChange change) =>
+        new(
+            change.FileName,
+            change.CurrentVirtualPath,
+            change.ProposedVirtualPath,
+            change.ChangeKind,
+            change.CollisionAdjusted);
+
+    private static bool TryParseQueueStatus(string value, out MetadataReviewStatus status)
+    {
+        if (value.Equals("pending", StringComparison.OrdinalIgnoreCase))
+        {
+            status = MetadataReviewStatus.Pending;
+            return true;
+        }
+        if (value.Equals("lowConfidence", StringComparison.OrdinalIgnoreCase)
+            || value.Equals("low-confidence", StringComparison.OrdinalIgnoreCase))
+        {
+            status = MetadataReviewStatus.LowConfidence;
+            return true;
+        }
+        if (value.Equals("failed", StringComparison.OrdinalIgnoreCase))
+        {
+            status = MetadataReviewStatus.Failed;
+            return true;
+        }
+
+        status = default;
+        return false;
+    }
+
+    private static string ToExternalStatus(MetadataReviewStatus status) => status switch
+    {
+        MetadataReviewStatus.Pending => "pending",
+        MetadataReviewStatus.LowConfidence => "lowConfidence",
+        MetadataReviewStatus.Failed => "failed",
+        MetadataReviewStatus.Identified => "identified",
+        MetadataReviewStatus.Reviewed => "reviewed",
+        _ => throw new ArgumentOutOfRangeException(nameof(status), status, null)
+    };
+}

--- a/SecondDimensionWatcherReDive/Migrations/20260827130549_AddMetadataReviewCenter.Designer.cs
+++ b/SecondDimensionWatcherReDive/Migrations/20260827130549_AddMetadataReviewCenter.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SecondDimensionWatcherReDive.Models;
@@ -11,9 +12,11 @@ using SecondDimensionWatcherReDive.Models;
 namespace SecondDimensionWatcherReDive.Migrations
 {
     [DbContext(typeof(ApplicationContext))]
-    partial class ApplicationContextModelSnapshot : ModelSnapshot
+    [Migration("20260827130549_AddMetadataReviewCenter")]
+    partial class AddMetadataReviewCenter
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SecondDimensionWatcherReDive/Migrations/20260827130549_AddMetadataReviewCenter.cs
+++ b/SecondDimensionWatcherReDive/Migrations/20260827130549_AddMetadataReviewCenter.cs
@@ -1,0 +1,319 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SecondDimensionWatcherReDive.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMetadataReviewCenter : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "CurrentMetadataReviewOperationId",
+                table: "AnimationInfo",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "MetadataConfidence",
+                table: "AnimationInfo",
+                type: "double precision",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "MetadataLastError",
+                table: "AnimationInfo",
+                type: "character varying(1024)",
+                maxLength: 1024,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "MetadataReviewedAt",
+                table: "AnimationInfo",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "MetadataStatus",
+                table: "AnimationInfo",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<long>(
+                name: "StateVersion",
+                table: "AnimationInfo",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L);
+
+            migrationBuilder.Sql(
+                """
+                UPDATE "AnimationInfo"
+                SET "MetadataStatus" = CASE
+                    WHEN "IsAiProcessed" THEN 1
+                    WHEN "AiRetryCount" >= 3 THEN 3
+                    ELSE 0
+                END
+                """);
+
+            migrationBuilder.CreateTable(
+                name: "MetadataReviewOperations",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AnimationInfoId = table.Column<Guid>(type: "uuid", nullable: false),
+                    State = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ExpiresAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    BaseVersion = table.Column<long>(type: "bigint", nullable: false),
+                    BaseFileStore = table.Column<string>(type: "text", nullable: true),
+                    BaseStorePath = table.Column<string>(type: "text", nullable: true),
+                    BaseIsDownloadFinished = table.Column<bool>(type: "boolean", nullable: false),
+                    ProposedAnimationTmdbId = table.Column<string>(type: "text", nullable: false),
+                    ProposedAnimationName = table.Column<string>(type: "text", nullable: false),
+                    ProposedAnimationOriginalName = table.Column<string>(type: "text", nullable: false),
+                    ProposedAnimationPosterPath = table.Column<string>(type: "text", nullable: true),
+                    ProposedDescription = table.Column<string>(type: "text", nullable: false),
+                    ProposedSeason = table.Column<int>(type: "integer", nullable: true),
+                    ProposedEpisode = table.Column<int>(type: "integer", nullable: true),
+                    ProposedGroupName = table.Column<string>(type: "text", nullable: true),
+                    AppliedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    UndoneAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    AppliedVersion = table.Column<long>(type: "bigint", nullable: true),
+                    PreviousDescription = table.Column<string>(type: "text", nullable: true),
+                    PreviousAnimationId = table.Column<Guid>(type: "uuid", nullable: true),
+                    PreviousGroupId = table.Column<Guid>(type: "uuid", nullable: true),
+                    PreviousSeason = table.Column<int>(type: "integer", nullable: true),
+                    PreviousEpisode = table.Column<int>(type: "integer", nullable: true),
+                    PreviousMetadataStatus = table.Column<int>(type: "integer", nullable: true),
+                    PreviousConfidence = table.Column<double>(type: "double precision", nullable: true),
+                    PreviousLastError = table.Column<string>(type: "text", nullable: true),
+                    PreviousIsAiProcessed = table.Column<bool>(type: "boolean", nullable: true),
+                    PreviousAiRetryCount = table.Column<int>(type: "integer", nullable: true),
+                    PreviousReviewedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    PreviousCurrentOperationId = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MetadataReviewOperations", x => x.Id);
+                    table.CheckConstraint("CK_MetadataReviewOperations_Expiry", "\"ExpiresAt\" > \"CreatedAt\"");
+                    table.ForeignKey(
+                        name: "FK_MetadataReviewOperations_AnimationInfo_AnimationInfoId",
+                        column: x => x.AnimationInfoId,
+                        principalTable: "AnimationInfo",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MetadataReviewMappingSnapshots",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OperationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Kind = table.Column<int>(type: "integer", nullable: false),
+                    VirtualPath = table.Column<string>(type: "text", nullable: false),
+                    PhysicalPath = table.Column<string>(type: "text", nullable: false),
+                    FileStore = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MetadataReviewMappingSnapshots", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MetadataReviewMappingSnapshots_MetadataReviewOperations_Ope~",
+                        column: x => x.OperationId,
+                        principalTable: "MetadataReviewOperations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.Sql(
+                """
+                WITH ranked_rules AS (
+                    SELECT rules."Id",
+                           row_number() OVER (
+                               PARTITION BY animations."TmdbId", rules."Pattern"
+                               ORDER BY animations."Id", rules."CreatedAt", rules."Id") AS duplicate_rank
+                    FROM "FileNameRegexRules" AS rules
+                    INNER JOIN "Animations" AS animations
+                        ON animations."Id" = rules."AnimationId"
+                )
+                DELETE FROM "FileNameRegexRules" AS rules
+                USING ranked_rules
+                WHERE rules."Id" = ranked_rules."Id"
+                  AND ranked_rules.duplicate_rank > 1;
+
+                WITH ranked_animations AS (
+                    SELECT animations."Id",
+                           first_value(animations."Id") OVER (
+                               PARTITION BY animations."TmdbId"
+                               ORDER BY animations."Id") AS keep_id
+                    FROM "Animations" AS animations
+                )
+                UPDATE "FileNameRegexRules" AS rules
+                SET "AnimationId" = ranked_animations.keep_id
+                FROM ranked_animations
+                WHERE rules."AnimationId" = ranked_animations."Id"
+                  AND ranked_animations."Id" <> ranked_animations.keep_id;
+
+                WITH ranked_animations AS (
+                    SELECT animations."Id",
+                           first_value(animations."Id") OVER (
+                               PARTITION BY animations."TmdbId"
+                               ORDER BY animations."Id") AS keep_id
+                    FROM "Animations" AS animations
+                )
+                UPDATE "AnimationInfo" AS info
+                SET "AnimationId" = ranked_animations.keep_id
+                FROM ranked_animations
+                WHERE info."AnimationId" = ranked_animations."Id"
+                  AND ranked_animations."Id" <> ranked_animations.keep_id;
+
+                WITH ranked_animations AS (
+                    SELECT animations."Id",
+                           first_value(animations."Id") OVER (
+                               PARTITION BY animations."TmdbId"
+                               ORDER BY animations."Id") AS keep_id
+                    FROM "Animations" AS animations
+                )
+                DELETE FROM "Animations" AS animations
+                USING ranked_animations
+                WHERE animations."Id" = ranked_animations."Id"
+                  AND ranked_animations."Id" <> ranked_animations.keep_id;
+
+                WITH ranked_groups AS (
+                    SELECT groups."Id",
+                           first_value(groups."Id") OVER (
+                               PARTITION BY groups."Name"
+                               ORDER BY groups."Id") AS keep_id
+                    FROM "AnimationGroups" AS groups
+                )
+                UPDATE "AnimationInfo" AS info
+                SET "GroupId" = ranked_groups.keep_id
+                FROM ranked_groups
+                WHERE info."GroupId" = ranked_groups."Id"
+                  AND ranked_groups."Id" <> ranked_groups.keep_id;
+
+                WITH ranked_groups AS (
+                    SELECT groups."Id",
+                           first_value(groups."Id") OVER (
+                               PARTITION BY groups."Name"
+                               ORDER BY groups."Id") AS keep_id
+                    FROM "AnimationGroups" AS groups
+                )
+                DELETE FROM "AnimationGroups" AS groups
+                USING ranked_groups
+                WHERE groups."Id" = ranked_groups."Id"
+                  AND ranked_groups."Id" <> ranked_groups.keep_id;
+                """);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Animations_TmdbId",
+                table: "Animations",
+                column: "TmdbId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AnimationInfo_CurrentMetadataReviewOperationId",
+                table: "AnimationInfo",
+                column: "CurrentMetadataReviewOperationId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AnimationInfo_MetadataStatus_PublishTime",
+                table: "AnimationInfo",
+                columns: new[] { "MetadataStatus", "PublishTime" });
+
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_AnimationInfo_MetadataConfidence_Range",
+                table: "AnimationInfo",
+                sql: "\"MetadataConfidence\" IS NULL OR (\"MetadataConfidence\" >= 0 AND \"MetadataConfidence\" <= 1)");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AnimationGroups_Name",
+                table: "AnimationGroups",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MetadataReviewMappingSnapshots_OperationId_Kind_VirtualPath",
+                table: "MetadataReviewMappingSnapshots",
+                columns: new[] { "OperationId", "Kind", "VirtualPath" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MetadataReviewOperations_AnimationInfoId_AppliedVersion",
+                table: "MetadataReviewOperations",
+                columns: new[] { "AnimationInfoId", "AppliedVersion" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MetadataReviewOperations_AnimationInfoId_State",
+                table: "MetadataReviewOperations",
+                columns: new[] { "AnimationInfoId", "State" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MetadataReviewOperations_State_ExpiresAt",
+                table: "MetadataReviewOperations",
+                columns: new[] { "State", "ExpiresAt" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MetadataReviewMappingSnapshots");
+
+            migrationBuilder.DropTable(
+                name: "MetadataReviewOperations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Animations_TmdbId",
+                table: "Animations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AnimationInfo_CurrentMetadataReviewOperationId",
+                table: "AnimationInfo");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AnimationInfo_MetadataStatus_PublishTime",
+                table: "AnimationInfo");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_AnimationInfo_MetadataConfidence_Range",
+                table: "AnimationInfo");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AnimationGroups_Name",
+                table: "AnimationGroups");
+
+            migrationBuilder.DropColumn(
+                name: "CurrentMetadataReviewOperationId",
+                table: "AnimationInfo");
+
+            migrationBuilder.DropColumn(
+                name: "MetadataConfidence",
+                table: "AnimationInfo");
+
+            migrationBuilder.DropColumn(
+                name: "MetadataLastError",
+                table: "AnimationInfo");
+
+            migrationBuilder.DropColumn(
+                name: "MetadataReviewedAt",
+                table: "AnimationInfo");
+
+            migrationBuilder.DropColumn(
+                name: "MetadataStatus",
+                table: "AnimationInfo");
+
+            migrationBuilder.DropColumn(
+                name: "StateVersion",
+                table: "AnimationInfo");
+        }
+    }
+}

--- a/SecondDimensionWatcherReDive/Models/AnimationInfo.cs
+++ b/SecondDimensionWatcherReDive/Models/AnimationInfo.cs
@@ -1,3 +1,5 @@
+using SecondDimensionWatcherReDive.Framework.DataRepository;
+
 namespace SecondDimensionWatcherReDive.Models;
 
 public class AnimationInfo
@@ -39,4 +41,16 @@ public class AnimationInfo
     public bool IsAiProcessed { get; set; }
 
     public int AiRetryCount { get; set; }
+
+    public MetadataReviewStatus MetadataStatus { get; set; }
+
+    public double? MetadataConfidence { get; set; }
+
+    public string? MetadataLastError { get; set; }
+
+    public DateTimeOffset? MetadataReviewedAt { get; set; }
+
+    public long StateVersion { get; set; }
+
+    public Guid? CurrentMetadataReviewOperationId { get; set; }
 }

--- a/SecondDimensionWatcherReDive/Models/ApplicationContext.cs
+++ b/SecondDimensionWatcherReDive/Models/ApplicationContext.cs
@@ -24,9 +24,70 @@ public class ApplicationContext : DbContext
     public DbSet<FileNameRegexRule> FileNameRegexRules { get; set; }
     public DbSet<MigrationMarker> MigrationMarkers { get; set; }
     public DbSet<WebDavToken> WebDavTokens { get; set; }
+    public DbSet<MetadataReviewOperation> MetadataReviewOperations { get; set; }
+    public DbSet<MetadataReviewMappingSnapshot> MetadataReviewMappingSnapshots { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        modelBuilder.Entity<Animation>()
+            .HasIndex(animation => animation.TmdbId)
+            .IsUnique();
+
+        modelBuilder.Entity<AnimationGroup>()
+            .HasIndex(group => group.Name)
+            .IsUnique();
+
+        modelBuilder.Entity<AnimationInfo>()
+            .Property(info => info.StateVersion)
+            .IsConcurrencyToken();
+
+        modelBuilder.Entity<AnimationInfo>()
+            .Property(info => info.MetadataLastError)
+            .HasMaxLength(1024);
+
+        modelBuilder.Entity<AnimationInfo>()
+            .ToTable(table => table.HasCheckConstraint(
+                "CK_AnimationInfo_MetadataConfidence_Range",
+                "\"MetadataConfidence\" IS NULL OR (\"MetadataConfidence\" >= 0 AND \"MetadataConfidence\" <= 1)"));
+
+        modelBuilder.Entity<AnimationInfo>()
+            .HasIndex(info => new { info.MetadataStatus, info.PublishTime });
+
+        modelBuilder.Entity<AnimationInfo>()
+            .HasIndex(info => info.CurrentMetadataReviewOperationId)
+            .IsUnique();
+
+        modelBuilder.Entity<MetadataReviewOperation>()
+            .HasOne(operation => operation.AnimationInfo)
+            .WithMany()
+            .HasForeignKey(operation => operation.AnimationInfoId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<MetadataReviewOperation>()
+            .HasIndex(operation => new { operation.AnimationInfoId, operation.State });
+
+        modelBuilder.Entity<MetadataReviewOperation>()
+            .HasIndex(operation => new { operation.State, operation.ExpiresAt });
+
+        modelBuilder.Entity<MetadataReviewOperation>()
+            .HasIndex(operation => new { operation.AnimationInfoId, operation.AppliedVersion })
+            .IsUnique();
+
+        modelBuilder.Entity<MetadataReviewOperation>()
+            .ToTable(table => table.HasCheckConstraint(
+                "CK_MetadataReviewOperations_Expiry",
+                "\"ExpiresAt\" > \"CreatedAt\""));
+
+        modelBuilder.Entity<MetadataReviewMappingSnapshot>()
+            .HasOne(snapshot => snapshot.Operation)
+            .WithMany(operation => operation.MappingSnapshots)
+            .HasForeignKey(snapshot => snapshot.OperationId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<MetadataReviewMappingSnapshot>()
+            .HasIndex(snapshot => new { snapshot.OperationId, snapshot.Kind, snapshot.VirtualPath })
+            .IsUnique();
+
         modelBuilder.Entity<MigrationMarker>()
             .HasKey(m => m.Key);
 

--- a/SecondDimensionWatcherReDive/Models/MetadataReviewMappingSnapshot.cs
+++ b/SecondDimensionWatcherReDive/Models/MetadataReviewMappingSnapshot.cs
@@ -1,0 +1,20 @@
+using SecondDimensionWatcherReDive.Framework.DataRepository;
+
+namespace SecondDimensionWatcherReDive.Models;
+
+public class MetadataReviewMappingSnapshot
+{
+    public Guid Id { get; set; }
+
+    public Guid OperationId { get; set; }
+
+    public MetadataReviewOperation Operation { get; set; } = null!;
+
+    public MetadataReviewMappingKind Kind { get; set; }
+
+    public string VirtualPath { get; set; } = string.Empty;
+
+    public string PhysicalPath { get; set; } = string.Empty;
+
+    public string FileStore { get; set; } = string.Empty;
+}

--- a/SecondDimensionWatcherReDive/Models/MetadataReviewOperation.cs
+++ b/SecondDimensionWatcherReDive/Models/MetadataReviewOperation.cs
@@ -1,0 +1,74 @@
+using SecondDimensionWatcherReDive.Framework.DataRepository;
+
+namespace SecondDimensionWatcherReDive.Models;
+
+public class MetadataReviewOperation
+{
+    public Guid Id { get; set; }
+
+    public Guid AnimationInfoId { get; set; }
+
+    public AnimationInfo AnimationInfo { get; set; } = null!;
+
+    public MetadataReviewOperationState State { get; set; }
+
+    public DateTimeOffset CreatedAt { get; set; }
+
+    public DateTimeOffset ExpiresAt { get; set; }
+
+    public long BaseVersion { get; set; }
+
+    public string? BaseFileStore { get; set; }
+
+    public string? BaseStorePath { get; set; }
+
+    public bool BaseIsDownloadFinished { get; set; }
+
+    public string ProposedAnimationTmdbId { get; set; } = string.Empty;
+
+    public string ProposedAnimationName { get; set; } = string.Empty;
+
+    public string ProposedAnimationOriginalName { get; set; } = string.Empty;
+
+    public string? ProposedAnimationPosterPath { get; set; }
+
+    public string ProposedDescription { get; set; } = string.Empty;
+
+    public int? ProposedSeason { get; set; }
+
+    public int? ProposedEpisode { get; set; }
+
+    public string? ProposedGroupName { get; set; }
+
+    public DateTimeOffset? AppliedAt { get; set; }
+
+    public DateTimeOffset? UndoneAt { get; set; }
+
+    public long? AppliedVersion { get; set; }
+
+    public string? PreviousDescription { get; set; }
+
+    public Guid? PreviousAnimationId { get; set; }
+
+    public Guid? PreviousGroupId { get; set; }
+
+    public int? PreviousSeason { get; set; }
+
+    public int? PreviousEpisode { get; set; }
+
+    public MetadataReviewStatus? PreviousMetadataStatus { get; set; }
+
+    public double? PreviousConfidence { get; set; }
+
+    public string? PreviousLastError { get; set; }
+
+    public bool? PreviousIsAiProcessed { get; set; }
+
+    public int? PreviousAiRetryCount { get; set; }
+
+    public DateTimeOffset? PreviousReviewedAt { get; set; }
+
+    public Guid? PreviousCurrentOperationId { get; set; }
+
+    public ICollection<MetadataReviewMappingSnapshot> MappingSnapshots { get; set; } = [];
+}

--- a/SecondDimensionWatcherReDive/Program.cs
+++ b/SecondDimensionWatcherReDive/Program.cs
@@ -29,6 +29,7 @@ using SecondDimensionWatcherReDive.MigrationTasks;
 using SecondDimensionWatcherReDive.Utils.Feed;
 using SecondDimensionWatcherReDive.Utils.FileDownload;
 using SecondDimensionWatcherReDive.Utils.FileStore;
+using SecondDimensionWatcherReDive.Utils.MetadataReview;
 using SecondDimensionWatcherReDive.Utils.Scraper;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -208,11 +209,14 @@ builder.Services.AddScoped<IBangumiSubgroupRepository, BangumiSubgroupRepository
 builder.Services.AddScoped<IChatRepository, ChatRepository>();
 builder.Services.AddScoped<IFileMappingRepository, FileMappingRepository>();
 builder.Services.AddScoped<IFileNameRegexRuleRepository, FileNameRegexRuleRepository>();
+builder.Services.AddScoped<IMetadataReviewRepository, MetadataReviewRepository>();
 builder.Services.AddScoped<IMigrationMarkerRepository, MigrationMarkerRepository>();
 builder.Services.AddScoped<IWebDavTokenRepository, WebDavTokenRepository>();
 builder.Services.AddSingleton<ISeasonScraper, MikananiSeasonScraper>();
+builder.Services.AddScoped<IMetadataReviewService, MetadataReviewService>();
 
 //Add AI Inference
+builder.Services.AddTmdbMetadata(builder.Configuration);
 var aiProvider = builder.Configuration["AI:Provider"]
     is { Length: > 0 } p
     ? p

--- a/SecondDimensionWatcherReDive/Repositories/AnimationInfoRepository.cs
+++ b/SecondDimensionWatcherReDive/Repositories/AnimationInfoRepository.cs
@@ -128,7 +128,9 @@ public class AnimationInfoRepository(Models.ApplicationContext context) : IAnima
     public async Task<IReadOnlyList<AnimationInfo>> GetPendingInferenceAsync(int maxRetryCount, CancellationToken cancellationToken)
     {
         var entities = await context.AnimationInfo
-            .Where(i => !i.IsAiProcessed && i.AiRetryCount < maxRetryCount)
+            .Where(i => !i.IsAiProcessed
+                        && i.AiRetryCount < maxRetryCount
+                        && i.MetadataStatus == MetadataReviewStatus.Pending)
             .OrderBy(i => i.PublishTime)
             .ToListAsync(cancellationToken);
         return entities.Select(e => e.ToRecord()).ToList();
@@ -151,14 +153,53 @@ public class AnimationInfoRepository(Models.ApplicationContext context) : IAnima
     {
         var entity = await context.AnimationInfo.FindAsync([info.Id], cancellationToken)
                      ?? throw new InvalidOperationException($"AnimationInfo {info.Id} not found");
+        var currentStateVersion = entity.StateVersion;
+        if (currentStateVersion != info.StateVersion)
+            throw new DbUpdateConcurrencyException(
+                $"AnimationInfo {info.Id} changed from revision {info.StateVersion} to {currentStateVersion}.");
+
         info.ApplyTo(entity);
 
-        if (info.Animation != null)
-            entity.Animation = await context.Animations.FindAsync([info.Animation.Id], cancellationToken);
-
-        if (info.Group != null)
-            entity.Group = await context.AnimationGroups.FindAsync([info.Group.Id], cancellationToken);
+        entity.Animation = info.Animation is null
+            ? null
+            : await context.Animations.FindAsync([info.Animation.Id], cancellationToken);
+        entity.Group = info.Group is null
+            ? null
+            : await context.AnimationGroups.FindAsync([info.Group.Id], cancellationToken);
+        entity.StateVersion = checked(currentStateVersion + 1);
 
         await context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<bool> TryUpdateAsync(
+        AnimationInfo info,
+        long expectedStateVersion,
+        CancellationToken cancellationToken)
+    {
+        var entity = await context.AnimationInfo
+            .FirstOrDefaultAsync(candidate => candidate.Id == info.Id, cancellationToken);
+        if (entity is null || entity.StateVersion != expectedStateVersion)
+            return false;
+
+        info.ApplyTo(entity);
+        entity.Animation = info.Animation is null
+            ? null
+            : await context.Animations.FindAsync([info.Animation.Id], cancellationToken);
+        entity.Group = info.Group is null
+            ? null
+            : await context.AnimationGroups.FindAsync([info.Group.Id], cancellationToken);
+        entity.StateVersion = checked(expectedStateVersion + 1);
+        context.Entry(entity).Property(candidate => candidate.StateVersion).OriginalValue = expectedStateVersion;
+
+        try
+        {
+            await context.SaveChangesAsync(cancellationToken);
+            return true;
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            context.Entry(entity).State = EntityState.Detached;
+            return false;
+        }
     }
 }

--- a/SecondDimensionWatcherReDive/Repositories/FileMappingRepository.cs
+++ b/SecondDimensionWatcherReDive/Repositories/FileMappingRepository.cs
@@ -10,17 +10,54 @@ public class FileMappingRepository(
     public async Task AddRangeAsync(IReadOnlyList<FileMapping> mappings, CancellationToken cancellationToken)
     {
         if (mappings.Count == 0) return;
-        await context.FileMappings.AddRangeAsync(mappings.Select(m => m.ToEntity()), cancellationToken);
-        await context.SaveChangesAsync(cancellationToken);
+
+        var animationInfoIds = mappings
+            .Select(mapping => mapping.AnimationInfoId)
+            .Distinct()
+            .ToArray();
+        var strategy = context.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
+        {
+            await using var writeContext = new Models.ApplicationContext(contextOptions);
+            await using var transaction = await writeContext.Database
+                .BeginTransactionAsync(cancellationToken);
+
+            await MappingTransactionLock.AcquireAsync(writeContext, cancellationToken);
+            var animationInfos = await MappingTransactionLock.LockAnimationInfosAsync(
+                writeContext,
+                animationInfoIds,
+                cancellationToken);
+            if (animationInfos.Count != animationInfoIds.Length)
+                throw new InvalidOperationException("Cannot add mappings for a missing AnimationInfo.");
+
+            await writeContext.FileMappings.AddRangeAsync(
+                mappings.Select(mapping => mapping.ToEntity()),
+                cancellationToken);
+            foreach (var animationInfo in animationInfos.Values)
+                animationInfo.StateVersion = checked(animationInfo.StateVersion + 1);
+
+            await writeContext.SaveChangesAsync(cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+        });
     }
 
     public async Task<bool> ReplaceForAnimationInfoAsync(
         Guid animationInfoId,
+        long expectedStateVersion,
         string expectedFileStore,
         string expectedStorePath,
         IReadOnlyList<FileMapping> mappings,
         CancellationToken cancellationToken)
     {
+        if (mappings.Any(mapping => mapping.AnimationInfoId != animationInfoId))
+            throw new ArgumentException(
+                "Every replacement mapping must belong to the requested AnimationInfo.",
+                nameof(mappings));
+
+        var proposedPaths = mappings.Select(mapping => mapping.VirtualPath).ToArray();
+        if (proposedPaths.Distinct(StringComparer.Ordinal).Count() != proposedPaths.Length)
+            return false;
+
         var strategy = context.Database.CreateExecutionStrategy();
         return await strategy.ExecuteAsync(async () =>
         {
@@ -30,26 +67,23 @@ public class FileMappingRepository(
             await using var transaction = await replaceContext.Database
                 .BeginTransactionAsync(cancellationToken);
 
-            // Serialize all replacements for one download across app instances. The lock is
-            // held until commit; the following READ COMMITTED delete sees the latest mapping set.
-            await replaceContext.Database.ExecuteSqlInterpolatedAsync(
-                $"""SELECT 1 FROM "AnimationInfo" WHERE "Id" = {animationInfoId} FOR UPDATE""",
+            await MappingTransactionLock.AcquireAsync(replaceContext, cancellationToken);
+            var current = await MappingTransactionLock.LockAnimationInfoAsync(
+                replaceContext,
+                animationInfoId,
                 cancellationToken);
-
-            var current = await replaceContext.AnimationInfo
-                .AsNoTracking()
-                .Where(info => info.Id == animationInfoId)
-                .Select(info => new
-                {
-                    info.IsDownloadFinished,
-                    info.FileStore,
-                    info.StorePath
-                })
-                .SingleOrDefaultAsync(cancellationToken);
             if (current is null
+                || current.StateVersion != expectedStateVersion
                 || !current.IsDownloadFinished
                 || current.FileStore != expectedFileStore
                 || current.StorePath != expectedStorePath)
+                return false;
+
+            if (proposedPaths.Length > 0
+                && await replaceContext.FileMappings.AnyAsync(
+                    mapping => mapping.AnimationInfoId != animationInfoId
+                               && proposedPaths.Contains(mapping.VirtualPath),
+                    cancellationToken))
                 return false;
 
             await replaceContext.FileMappings
@@ -59,10 +93,23 @@ public class FileMappingRepository(
                 await replaceContext.FileMappings.AddRangeAsync(
                     mappings.Select(mapping => mapping.ToEntity()),
                     cancellationToken);
+            current.StateVersion = checked(current.StateVersion + 1);
             await replaceContext.SaveChangesAsync(cancellationToken);
             await transaction.CommitAsync(cancellationToken);
             return true;
         });
+    }
+
+    public async Task<IReadOnlyList<FileMapping>> GetForAnimationInfoAsync(
+        Guid animationInfoId,
+        CancellationToken cancellationToken)
+    {
+        var entities = await context.FileMappings
+            .AsNoTracking()
+            .Where(mapping => mapping.AnimationInfoId == animationInfoId)
+            .OrderBy(mapping => mapping.VirtualPath)
+            .ToListAsync(cancellationToken);
+        return entities.Select(entity => entity.ToRecord()).ToList();
     }
 
     public async Task<FileMapping?> FindByVirtualPathAsync(string virtualPath, CancellationToken cancellationToken)
@@ -129,8 +176,28 @@ public class FileMappingRepository(
 
     public async Task RemoveByAnimationInfoAsync(Guid animationInfoId, CancellationToken cancellationToken)
     {
-        await context.FileMappings
-            .Where(m => m.AnimationInfoId == animationInfoId)
-            .ExecuteDeleteAsync(cancellationToken);
+        var strategy = context.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
+        {
+            await using var removeContext = new Models.ApplicationContext(contextOptions);
+            await using var transaction = await removeContext.Database
+                .BeginTransactionAsync(cancellationToken);
+
+            await MappingTransactionLock.AcquireAsync(removeContext, cancellationToken);
+            var animationInfo = await MappingTransactionLock.LockAnimationInfoAsync(
+                removeContext,
+                animationInfoId,
+                cancellationToken);
+            await removeContext.FileMappings
+                .Where(mapping => mapping.AnimationInfoId == animationInfoId)
+                .ExecuteDeleteAsync(cancellationToken);
+            if (animationInfo is not null)
+            {
+                animationInfo.StateVersion = checked(animationInfo.StateVersion + 1);
+                await removeContext.SaveChangesAsync(cancellationToken);
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+        });
     }
 }

--- a/SecondDimensionWatcherReDive/Repositories/MappingTransactionLock.cs
+++ b/SecondDimensionWatcherReDive/Repositories/MappingTransactionLock.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace SecondDimensionWatcherReDive.Repositories;
+
+/// <summary>
+/// Establishes the lock order shared by every transaction that mutates the
+/// virtual-path namespace: global advisory transaction lock, then aggregate
+/// rows ordered by identifier.
+/// </summary>
+internal static class MappingTransactionLock
+{
+    // Stable application-owned PostgreSQL advisory lock key ("SDWRMAP1").
+    private const long MappingNamespaceLockKey = 0x534457524D415031;
+
+    public static async Task AcquireAsync(
+        Models.ApplicationContext context,
+        CancellationToken cancellationToken)
+    {
+        await context.Database.ExecuteSqlInterpolatedAsync(
+            $"SELECT pg_advisory_xact_lock({MappingNamespaceLockKey})",
+            cancellationToken);
+    }
+
+    public static async Task<Models.AnimationInfo?> LockAnimationInfoAsync(
+        Models.ApplicationContext context,
+        Guid animationInfoId,
+        CancellationToken cancellationToken)
+    {
+        await LockAnimationInfoRowsAsync(context, [animationInfoId], cancellationToken);
+        return await context.AnimationInfo
+            .SingleOrDefaultAsync(info => info.Id == animationInfoId, cancellationToken);
+    }
+
+    public static async Task<IReadOnlyDictionary<Guid, Models.AnimationInfo>> LockAnimationInfosAsync(
+        Models.ApplicationContext context,
+        IEnumerable<Guid> animationInfoIds,
+        CancellationToken cancellationToken)
+    {
+        var orderedIds = animationInfoIds.Distinct().Order().ToArray();
+        await LockAnimationInfoRowsAsync(context, orderedIds, cancellationToken);
+
+        var entities = await context.AnimationInfo
+            .Where(info => orderedIds.Contains(info.Id))
+            .ToListAsync(cancellationToken);
+        return entities.ToDictionary(info => info.Id);
+    }
+
+    private static async Task LockAnimationInfoRowsAsync(
+        Models.ApplicationContext context,
+        IEnumerable<Guid> orderedAnimationInfoIds,
+        CancellationToken cancellationToken)
+    {
+        foreach (var animationInfoId in orderedAnimationInfoIds)
+        {
+            await context.Database.ExecuteSqlInterpolatedAsync(
+                $"SELECT 1 FROM \"AnimationInfo\" WHERE \"Id\" = {animationInfoId} FOR UPDATE",
+                cancellationToken);
+        }
+    }
+}

--- a/SecondDimensionWatcherReDive/Repositories/MetadataReviewRepository.cs
+++ b/SecondDimensionWatcherReDive/Repositories/MetadataReviewRepository.cs
@@ -1,0 +1,725 @@
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using SecondDimensionWatcherReDive.Framework.DataRepository;
+using DataFileMapping = SecondDimensionWatcherReDive.Framework.DataRepository.FileMapping;
+
+namespace SecondDimensionWatcherReDive.Repositories;
+
+public class MetadataReviewRepository(
+    Models.ApplicationContext context,
+    DbContextOptions<Models.ApplicationContext> contextOptions) : IMetadataReviewRepository
+{
+    private const int RecentOperationLimit = 10;
+
+    public async Task<MetadataReviewQueuePage> GetQueueAsync(
+        MetadataReviewStatus status,
+        int skip,
+        int take,
+        CancellationToken cancellationToken)
+    {
+        var queueQuery = context.AnimationInfo
+            .AsNoTracking()
+            .Include(info => info.Animation)
+            .Include(info => info.Group)
+            .Where(info => info.MetadataStatus == status)
+            .OrderByDescending(info => info.PublishTime);
+
+        var totalCount = await queueQuery.CountAsync(cancellationToken);
+        var entities = await queueQuery
+            .Skip(skip)
+            .Take(take)
+            .ToListAsync(cancellationToken);
+        var animationInfoIds = entities.Select(info => info.Id).ToArray();
+
+        var mappingCounts = animationInfoIds.Length == 0
+            ? new Dictionary<Guid, int>()
+            : await context.FileMappings
+                .AsNoTracking()
+                .Where(mapping => animationInfoIds.Contains(mapping.AnimationInfoId))
+                .GroupBy(mapping => mapping.AnimationInfoId)
+                .Select(group => new { AnimationInfoId = group.Key, Count = group.Count() })
+                .ToDictionaryAsync(row => row.AnimationInfoId, row => row.Count, cancellationToken);
+
+        var operationIds = entities
+            .Where(info => info.CurrentMetadataReviewOperationId.HasValue)
+            .Select(info => info.CurrentMetadataReviewOperationId!.Value)
+            .Distinct()
+            .ToArray();
+        var currentOperations = operationIds.Length == 0
+            ? new Dictionary<Guid, CurrentOperationRow>()
+            : await context.MetadataReviewOperations
+                .AsNoTracking()
+                .Where(operation => operationIds.Contains(operation.Id))
+                .Select(operation => new CurrentOperationRow(
+                    operation.Id,
+                    operation.State,
+                    operation.AppliedAt,
+                    operation.AppliedVersion))
+                .ToDictionaryAsync(operation => operation.Id, cancellationToken);
+
+        var items = entities.Select(info =>
+        {
+            CurrentOperationRow? currentOperation = null;
+            if (info.CurrentMetadataReviewOperationId is { } operationId)
+                currentOperations.TryGetValue(operationId, out currentOperation);
+
+            var canUndo = currentOperation is
+            {
+                State: MetadataReviewOperationState.Applied,
+                AppliedVersion: not null
+            } && currentOperation.AppliedVersion == info.StateVersion;
+            return new MetadataReviewQueueItem(
+                info.ToRecord(),
+                mappingCounts.GetValueOrDefault(info.Id),
+                info.CurrentMetadataReviewOperationId,
+                currentOperation?.AppliedAt,
+                canUndo);
+        }).ToList();
+
+        var countedStatuses = new[]
+        {
+            MetadataReviewStatus.Pending,
+            MetadataReviewStatus.LowConfidence,
+            MetadataReviewStatus.Failed
+        };
+        var countRows = await context.AnimationInfo
+            .AsNoTracking()
+            .Where(info => countedStatuses.Contains(info.MetadataStatus))
+            .GroupBy(info => info.MetadataStatus)
+            .Select(group => new { Status = group.Key, Count = group.Count() })
+            .ToListAsync(cancellationToken);
+        var countsByStatus = countRows.ToDictionary(row => row.Status, row => row.Count);
+        var counts = new MetadataReviewCounts(
+            countsByStatus.GetValueOrDefault(MetadataReviewStatus.Pending),
+            countsByStatus.GetValueOrDefault(MetadataReviewStatus.LowConfidence),
+            countsByStatus.GetValueOrDefault(MetadataReviewStatus.Failed));
+
+        var recentRows = await context.MetadataReviewOperations
+            .AsNoTracking()
+            .Where(operation => operation.State == MetadataReviewOperationState.Applied
+                                && operation.AppliedAt.HasValue
+                                && operation.AppliedVersion.HasValue)
+            .OrderByDescending(operation => operation.AppliedAt)
+            .Take(RecentOperationLimit)
+            .Select(operation => new
+            {
+                operation.Id,
+                operation.AnimationInfoId,
+                operation.AnimationInfo.Title,
+                AppliedAt = operation.AppliedAt!.Value,
+                Revision = operation.AppliedVersion!.Value,
+                CurrentOperationId = operation.AnimationInfo.CurrentMetadataReviewOperationId,
+                CurrentRevision = operation.AnimationInfo.StateVersion
+            })
+            .ToListAsync(cancellationToken);
+        var recentOperations = recentRows
+            .Select(row => new MetadataReviewOperationSummary(
+                row.Id,
+                row.AnimationInfoId,
+                row.Title,
+                row.AppliedAt,
+                row.Revision,
+                row.CurrentOperationId == row.Id && row.CurrentRevision == row.Revision))
+            .ToList();
+
+        return new MetadataReviewQueuePage(items, totalCount, counts, recentOperations);
+    }
+
+    public async Task SavePreviewAsync(
+        MetadataReviewPreviewDraft draft,
+        CancellationToken cancellationToken)
+    {
+        if (draft.ExpiresAt <= draft.CreatedAt)
+            throw new ArgumentException("A metadata review preview must expire after it is created.", nameof(draft));
+        if (draft.ProposedMappings.Any(mapping => mapping.AnimationInfoId != draft.AnimationInfoId))
+            throw new ArgumentException(
+                "Every proposed mapping must belong to the previewed AnimationInfo.",
+                nameof(draft));
+        if (draft.ProposedMappings
+                .Select(mapping => mapping.VirtualPath)
+                .Distinct(StringComparer.Ordinal)
+                .Count() != draft.ProposedMappings.Count)
+            throw new ArgumentException("A preview cannot contain duplicate virtual paths.", nameof(draft));
+        if (!await context.AnimationInfo
+                .AsNoTracking()
+                .AnyAsync(info => info.Id == draft.AnimationInfoId, cancellationToken))
+            throw new InvalidOperationException($"AnimationInfo {draft.AnimationInfoId} not found.");
+
+        var operation = new Models.MetadataReviewOperation
+        {
+            Id = draft.Id,
+            AnimationInfoId = draft.AnimationInfoId,
+            State = MetadataReviewOperationState.Draft,
+            CreatedAt = draft.CreatedAt,
+            ExpiresAt = draft.ExpiresAt,
+            BaseVersion = draft.BaseVersion,
+            BaseFileStore = draft.BaseFileStore,
+            BaseStorePath = draft.BaseStorePath,
+            BaseIsDownloadFinished = draft.BaseIsDownloadFinished,
+            ProposedAnimationTmdbId = draft.ProposedAnimation.TmdbId,
+            ProposedAnimationName = draft.ProposedAnimation.Name,
+            ProposedAnimationOriginalName = draft.ProposedAnimation.OriginalName,
+            ProposedAnimationPosterPath = draft.ProposedAnimation.PosterPath,
+            ProposedDescription = draft.ProposedDescription,
+            ProposedSeason = draft.ProposedSeason,
+            ProposedEpisode = draft.ProposedEpisode,
+            ProposedGroupName = draft.ProposedGroupName,
+            MappingSnapshots = draft.ProposedMappings
+                .Select(mapping => new Models.MetadataReviewMappingSnapshot
+                {
+                    Id = Guid.NewGuid(),
+                    OperationId = draft.Id,
+                    Kind = MetadataReviewMappingKind.Proposed,
+                    VirtualPath = mapping.VirtualPath,
+                    PhysicalPath = mapping.PhysicalPath,
+                    FileStore = mapping.FileStore
+                })
+                .ToList()
+        };
+        await context.MetadataReviewOperations.AddAsync(operation, cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<MetadataReviewMutationResult> ApplyPreviewAsync(
+        Guid operationId,
+        Guid expectedAnimationInfoId,
+        CancellationToken cancellationToken)
+    {
+        var operationOwner = await context.MetadataReviewOperations
+            .AsNoTracking()
+            .Where(operation => operation.Id == operationId)
+            .Select(operation => (Guid?)operation.AnimationInfoId)
+            .SingleOrDefaultAsync(cancellationToken);
+        if (!operationOwner.HasValue || operationOwner.Value != expectedAnimationInfoId)
+            return Failure(MetadataReviewMutationOutcome.NotFound, operationId);
+
+        var strategy = context.Database.CreateExecutionStrategy();
+        try
+        {
+            return await strategy.ExecuteAsync(async () =>
+            {
+                await using var applyContext = new Models.ApplicationContext(contextOptions);
+                await using var transaction = await applyContext.Database
+                    .BeginTransactionAsync(cancellationToken);
+
+                await MappingTransactionLock.AcquireAsync(applyContext, cancellationToken);
+                var animationInfo = await MappingTransactionLock.LockAnimationInfoAsync(
+                    applyContext,
+                    expectedAnimationInfoId,
+                    cancellationToken);
+                var operation = await LockOperationAsync(applyContext, operationId, cancellationToken);
+                if (animationInfo is null || operation is null)
+                    return Failure(MetadataReviewMutationOutcome.NotFound, operationId);
+                if (operation.AnimationInfoId != expectedAnimationInfoId)
+                    return Failure(MetadataReviewMutationOutcome.NotFound, operationId);
+                if (operation.State == MetadataReviewOperationState.Applied)
+                {
+                    var currentMappings = await applyContext.FileMappings
+                        .AsNoTracking()
+                        .Where(mapping => mapping.AnimationInfoId == animationInfo.Id)
+                        .OrderBy(mapping => mapping.VirtualPath)
+                        .ToListAsync(cancellationToken);
+                    var appliedSnapshots = operation.MappingSnapshots
+                        .Where(snapshot => snapshot.Kind == MetadataReviewMappingKind.Proposed)
+                        .ToList();
+                    if (operation.AppliedVersion.HasValue
+                        && operation.AppliedAt.HasValue
+                        && animationInfo.CurrentMetadataReviewOperationId == operation.Id
+                        && animationInfo.StateVersion == operation.AppliedVersion.Value
+                        && MappingSetsMatch(currentMappings, appliedSnapshots))
+                        return new MetadataReviewMutationResult(
+                            MetadataReviewMutationOutcome.Success,
+                            operation.Id,
+                            animationInfo.Id,
+                            animationInfo.StateVersion,
+                            operation.AppliedAt.Value,
+                            SnapshotRecords(
+                                operation.MappingSnapshots,
+                                MetadataReviewMappingKind.Previous,
+                                animationInfo.Id),
+                            currentMappings.Select(mapping => mapping.ToRecord()).ToList());
+                }
+                if (operation.State != MetadataReviewOperationState.Draft)
+                    return Failure(
+                        MetadataReviewMutationOutcome.Conflict,
+                        operationId,
+                        animationInfo.Id);
+
+                var appliedAt = DateTimeOffset.UtcNow;
+                if (operation.ExpiresAt <= appliedAt)
+                {
+                    operation.State = MetadataReviewOperationState.Expired;
+                    await applyContext.SaveChangesAsync(cancellationToken);
+                    await transaction.CommitAsync(cancellationToken);
+                    return Failure(
+                        MetadataReviewMutationOutcome.Expired,
+                        operationId,
+                        animationInfo.Id);
+                }
+
+                if (animationInfo.StateVersion != operation.BaseVersion
+                    || animationInfo.FileStore != operation.BaseFileStore
+                    || animationInfo.StorePath != operation.BaseStorePath
+                    || animationInfo.IsDownloadFinished != operation.BaseIsDownloadFinished)
+                    return Failure(
+                        MetadataReviewMutationOutcome.Conflict,
+                        operationId,
+                        animationInfo.Id);
+
+                var proposedSnapshots = operation.MappingSnapshots
+                    .Where(snapshot => snapshot.Kind == MetadataReviewMappingKind.Proposed)
+                    .OrderBy(snapshot => snapshot.VirtualPath)
+                    .ToList();
+                var proposedPaths = proposedSnapshots.Select(snapshot => snapshot.VirtualPath).ToArray();
+                if (proposedPaths.Distinct(StringComparer.Ordinal).Count() != proposedPaths.Length
+                    || proposedPaths.Length > 0
+                    && await applyContext.FileMappings.AnyAsync(
+                        mapping => mapping.AnimationInfoId != animationInfo.Id
+                                   && proposedPaths.Contains(mapping.VirtualPath),
+                        cancellationToken))
+                    return Failure(
+                        MetadataReviewMutationOutcome.Conflict,
+                        operationId,
+                        animationInfo.Id);
+
+                var existingMappings = await applyContext.FileMappings
+                    .AsNoTracking()
+                    .Where(mapping => mapping.AnimationInfoId == animationInfo.Id)
+                    .OrderBy(mapping => mapping.VirtualPath)
+                    .ToListAsync(cancellationToken);
+                var mappingsBefore = existingMappings.Select(mapping => mapping.ToRecord()).ToList();
+
+                var animationInfoEntry = applyContext.Entry(animationInfo);
+                operation.PreviousDescription = animationInfo.Description;
+                operation.PreviousAnimationId = animationInfoEntry
+                    .Property<Guid?>("AnimationId")
+                    .CurrentValue;
+                operation.PreviousGroupId = animationInfoEntry
+                    .Property<Guid?>("GroupId")
+                    .CurrentValue;
+                operation.PreviousSeason = animationInfo.Season;
+                operation.PreviousEpisode = animationInfo.Episode;
+                operation.PreviousMetadataStatus = animationInfo.MetadataStatus;
+                operation.PreviousConfidence = animationInfo.MetadataConfidence;
+                operation.PreviousLastError = animationInfo.MetadataLastError;
+                operation.PreviousIsAiProcessed = animationInfo.IsAiProcessed;
+                operation.PreviousAiRetryCount = animationInfo.AiRetryCount;
+                operation.PreviousReviewedAt = animationInfo.MetadataReviewedAt;
+                operation.PreviousCurrentOperationId = animationInfo.CurrentMetadataReviewOperationId;
+                var previousMappingSnapshots = existingMappings
+                    .Select(mapping => new Models.MetadataReviewMappingSnapshot
+                    {
+                        Id = Guid.NewGuid(),
+                        OperationId = operation.Id,
+                        Operation = operation,
+                        Kind = MetadataReviewMappingKind.Previous,
+                        VirtualPath = mapping.VirtualPath,
+                        PhysicalPath = mapping.PhysicalPath,
+                        FileStore = mapping.FileStore
+                    })
+                    .ToList();
+                if (previousMappingSnapshots.Count > 0)
+                    await applyContext.MetadataReviewMappingSnapshots.AddRangeAsync(
+                        previousMappingSnapshots,
+                        cancellationToken);
+
+                var animation = await FindOrCreateAnimationAsync(
+                    applyContext,
+                    operation,
+                    cancellationToken);
+                var group = await FindOrCreateGroupAsync(
+                    applyContext,
+                    operation.ProposedGroupName,
+                    cancellationToken);
+
+                animationInfo.Description = operation.ProposedDescription;
+                animationInfo.Animation = animation;
+                animationInfo.Group = group;
+                animationInfo.Season = operation.ProposedSeason;
+                animationInfo.Episode = operation.ProposedEpisode;
+                animationInfo.MetadataStatus = MetadataReviewStatus.Reviewed;
+                animationInfo.MetadataConfidence = 1;
+                animationInfo.MetadataLastError = null;
+                animationInfo.IsAiProcessed = true;
+                animationInfo.AiRetryCount = 0;
+                animationInfo.MetadataReviewedAt = appliedAt;
+                animationInfo.CurrentMetadataReviewOperationId = operation.Id;
+                animationInfo.StateVersion = checked(animationInfo.StateVersion + 1);
+
+                var replacementMappings = proposedSnapshots
+                    .Select(snapshot => new Models.FileMapping
+                    {
+                        Id = Guid.NewGuid(),
+                        AnimationInfoId = animationInfo.Id,
+                        VirtualPath = snapshot.VirtualPath,
+                        PhysicalPath = snapshot.PhysicalPath,
+                        FileStore = snapshot.FileStore
+                    })
+                    .ToList();
+                await applyContext.FileMappings
+                    .Where(mapping => mapping.AnimationInfoId == animationInfo.Id)
+                    .ExecuteDeleteAsync(cancellationToken);
+                if (replacementMappings.Count > 0)
+                    await applyContext.FileMappings.AddRangeAsync(replacementMappings, cancellationToken);
+
+                operation.State = MetadataReviewOperationState.Applied;
+                operation.AppliedAt = appliedAt;
+                operation.UndoneAt = null;
+                operation.AppliedVersion = animationInfo.StateVersion;
+
+                await applyContext.SaveChangesAsync(cancellationToken);
+                await transaction.CommitAsync(cancellationToken);
+                return new MetadataReviewMutationResult(
+                    MetadataReviewMutationOutcome.Success,
+                    operation.Id,
+                    animationInfo.Id,
+                    animationInfo.StateVersion,
+                    appliedAt,
+                    mappingsBefore,
+                    replacementMappings.Select(mapping => mapping.ToRecord()).ToList());
+            });
+        }
+        catch (DbUpdateException exception) when (IsConstraintConflict(exception))
+        {
+            return Failure(
+                MetadataReviewMutationOutcome.Conflict,
+                operationId,
+                expectedAnimationInfoId);
+        }
+    }
+
+    public async Task<MetadataReviewMutationResult> UndoAsync(
+        Guid operationId,
+        long expectedVersion,
+        CancellationToken cancellationToken)
+    {
+        var operationOwner = await context.MetadataReviewOperations
+            .AsNoTracking()
+            .Where(operation => operation.Id == operationId)
+            .Select(operation => (Guid?)operation.AnimationInfoId)
+            .SingleOrDefaultAsync(cancellationToken);
+        if (!operationOwner.HasValue)
+            return Failure(MetadataReviewMutationOutcome.NotFound, operationId);
+
+        var animationInfoId = operationOwner.Value;
+        var strategy = context.Database.CreateExecutionStrategy();
+        try
+        {
+            return await strategy.ExecuteAsync(async () =>
+            {
+                await using var undoContext = new Models.ApplicationContext(contextOptions);
+                await using var transaction = await undoContext.Database
+                    .BeginTransactionAsync(cancellationToken);
+
+                await MappingTransactionLock.AcquireAsync(undoContext, cancellationToken);
+                var animationInfo = await MappingTransactionLock.LockAnimationInfoAsync(
+                    undoContext,
+                    animationInfoId,
+                    cancellationToken);
+                var operation = await LockOperationAsync(undoContext, operationId, cancellationToken);
+                if (animationInfo is null || operation is null)
+                    return Failure(MetadataReviewMutationOutcome.NotFound, operationId);
+                if (operation.State == MetadataReviewOperationState.Undone)
+                {
+                    var idempotentCurrentMappings = await undoContext.FileMappings
+                        .AsNoTracking()
+                        .Where(mapping => mapping.AnimationInfoId == animationInfo.Id)
+                        .OrderBy(mapping => mapping.VirtualPath)
+                        .ToListAsync(cancellationToken);
+                    var restoredSnapshots = operation.MappingSnapshots
+                        .Where(snapshot => snapshot.Kind == MetadataReviewMappingKind.Previous)
+                        .ToList();
+                    if (operation.AppliedVersion == expectedVersion
+                        && operation.UndoneAt.HasValue
+                        && expectedVersion < long.MaxValue
+                        && animationInfo.StateVersion == expectedVersion + 1
+                        && animationInfo.CurrentMetadataReviewOperationId
+                        == operation.PreviousCurrentOperationId
+                        && MappingSetsMatch(idempotentCurrentMappings, restoredSnapshots))
+                        return new MetadataReviewMutationResult(
+                            MetadataReviewMutationOutcome.Success,
+                            operation.Id,
+                            animationInfo.Id,
+                            animationInfo.StateVersion,
+                            operation.UndoneAt.Value,
+                            SnapshotRecords(
+                                operation.MappingSnapshots,
+                                MetadataReviewMappingKind.Proposed,
+                                animationInfo.Id),
+                            idempotentCurrentMappings.Select(mapping => mapping.ToRecord()).ToList());
+                }
+                if (operation.State != MetadataReviewOperationState.Applied
+                    || !operation.AppliedVersion.HasValue
+                    || animationInfo.CurrentMetadataReviewOperationId != operation.Id
+                    || animationInfo.StateVersion != expectedVersion
+                    || operation.AppliedVersion.Value != expectedVersion)
+                    return Failure(
+                        MetadataReviewMutationOutcome.Conflict,
+                        operationId,
+                        animationInfo.Id);
+                if (operation.PreviousDescription is null
+                    || !operation.PreviousMetadataStatus.HasValue
+                    || !operation.PreviousIsAiProcessed.HasValue
+                    || !operation.PreviousAiRetryCount.HasValue)
+                    return Failure(
+                        MetadataReviewMutationOutcome.Conflict,
+                        operationId,
+                        animationInfo.Id);
+
+                var currentMappings = await undoContext.FileMappings
+                    .AsNoTracking()
+                    .Where(mapping => mapping.AnimationInfoId == animationInfo.Id)
+                    .OrderBy(mapping => mapping.VirtualPath)
+                    .ToListAsync(cancellationToken);
+                var proposedSnapshots = operation.MappingSnapshots
+                    .Where(snapshot => snapshot.Kind == MetadataReviewMappingKind.Proposed)
+                    .ToList();
+                if (!MappingSetsMatch(currentMappings, proposedSnapshots))
+                    return Failure(
+                        MetadataReviewMutationOutcome.Conflict,
+                        operationId,
+                        animationInfo.Id);
+
+                var previousSnapshots = operation.MappingSnapshots
+                    .Where(snapshot => snapshot.Kind == MetadataReviewMappingKind.Previous)
+                    .OrderBy(snapshot => snapshot.VirtualPath)
+                    .ToList();
+                var previousPaths = previousSnapshots.Select(snapshot => snapshot.VirtualPath).ToArray();
+                if (previousPaths.Length > 0
+                    && await undoContext.FileMappings.AnyAsync(
+                        mapping => mapping.AnimationInfoId != animationInfo.Id
+                                   && previousPaths.Contains(mapping.VirtualPath),
+                        cancellationToken))
+                    return Failure(
+                        MetadataReviewMutationOutcome.Conflict,
+                        operationId,
+                        animationInfo.Id);
+
+                Models.Animation? previousAnimation = null;
+                if (operation.PreviousAnimationId is { } previousAnimationId)
+                {
+                    previousAnimation = await undoContext.Animations.FindAsync(
+                        [previousAnimationId],
+                        cancellationToken);
+                    if (previousAnimation is null)
+                        return Failure(
+                            MetadataReviewMutationOutcome.Conflict,
+                            operationId,
+                            animationInfo.Id);
+                }
+
+                Models.AnimationGroup? previousGroup = null;
+                if (operation.PreviousGroupId is { } previousGroupId)
+                {
+                    previousGroup = await undoContext.AnimationGroups.FindAsync(
+                        [previousGroupId],
+                        cancellationToken);
+                    if (previousGroup is null)
+                        return Failure(
+                            MetadataReviewMutationOutcome.Conflict,
+                            operationId,
+                            animationInfo.Id);
+                }
+
+                Models.MetadataReviewOperation? previousOperation = null;
+                if (operation.PreviousCurrentOperationId is { } previousOperationId)
+                {
+                    if (previousOperationId == operation.Id)
+                        return Failure(
+                            MetadataReviewMutationOutcome.Conflict,
+                            operationId,
+                            animationInfo.Id);
+                    previousOperation = await LockOperationAsync(
+                        undoContext,
+                        previousOperationId,
+                        cancellationToken);
+                    if (previousOperation is null
+                        || previousOperation.AnimationInfoId != animationInfo.Id)
+                        return Failure(
+                            MetadataReviewMutationOutcome.Conflict,
+                            operationId,
+                            animationInfo.Id);
+                }
+
+                animationInfo.Description = operation.PreviousDescription;
+                animationInfo.Animation = previousAnimation;
+                animationInfo.Group = previousGroup;
+                animationInfo.Season = operation.PreviousSeason;
+                animationInfo.Episode = operation.PreviousEpisode;
+                animationInfo.MetadataStatus = operation.PreviousMetadataStatus.Value;
+                animationInfo.MetadataConfidence = operation.PreviousConfidence;
+                animationInfo.MetadataLastError = operation.PreviousLastError;
+                animationInfo.IsAiProcessed = operation.PreviousIsAiProcessed.Value;
+                animationInfo.AiRetryCount = operation.PreviousAiRetryCount.Value;
+                animationInfo.MetadataReviewedAt = operation.PreviousReviewedAt;
+                animationInfo.CurrentMetadataReviewOperationId = operation.PreviousCurrentOperationId;
+                animationInfo.StateVersion = checked(animationInfo.StateVersion + 1);
+
+                var restoredMappings = previousSnapshots
+                    .Select(snapshot => new Models.FileMapping
+                    {
+                        Id = Guid.NewGuid(),
+                        AnimationInfoId = animationInfo.Id,
+                        VirtualPath = snapshot.VirtualPath,
+                        PhysicalPath = snapshot.PhysicalPath,
+                        FileStore = snapshot.FileStore
+                    })
+                    .ToList();
+                await undoContext.FileMappings
+                    .Where(mapping => mapping.AnimationInfoId == animationInfo.Id)
+                    .ExecuteDeleteAsync(cancellationToken);
+                if (restoredMappings.Count > 0)
+                    await undoContext.FileMappings.AddRangeAsync(restoredMappings, cancellationToken);
+
+                var undoneAt = DateTimeOffset.UtcNow;
+                operation.State = MetadataReviewOperationState.Undone;
+                operation.UndoneAt = undoneAt;
+                if (previousOperation is
+                    {
+                        State: MetadataReviewOperationState.Applied,
+                        AppliedVersion: not null
+                    } && previousOperation.AppliedVersion == operation.BaseVersion)
+                    previousOperation.AppliedVersion = animationInfo.StateVersion;
+
+                await undoContext.SaveChangesAsync(cancellationToken);
+                await transaction.CommitAsync(cancellationToken);
+                return new MetadataReviewMutationResult(
+                    MetadataReviewMutationOutcome.Success,
+                    operation.Id,
+                    animationInfo.Id,
+                    animationInfo.StateVersion,
+                    undoneAt,
+                    currentMappings.Select(mapping => mapping.ToRecord()).ToList(),
+                    restoredMappings.Select(mapping => mapping.ToRecord()).ToList());
+            });
+        }
+        catch (DbUpdateException exception) when (IsConstraintConflict(exception))
+        {
+            return Failure(MetadataReviewMutationOutcome.Conflict, operationId, animationInfoId);
+        }
+    }
+
+    private static async Task<Models.MetadataReviewOperation?> LockOperationAsync(
+        Models.ApplicationContext operationContext,
+        Guid operationId,
+        CancellationToken cancellationToken)
+    {
+        await operationContext.Database.ExecuteSqlInterpolatedAsync(
+            $"SELECT 1 FROM \"MetadataReviewOperations\" WHERE \"Id\" = {operationId} FOR UPDATE",
+            cancellationToken);
+        return await operationContext.MetadataReviewOperations
+            .Include(operation => operation.MappingSnapshots)
+            .SingleOrDefaultAsync(operation => operation.Id == operationId, cancellationToken);
+    }
+
+    private static async Task<Models.Animation> FindOrCreateAnimationAsync(
+        Models.ApplicationContext operationContext,
+        Models.MetadataReviewOperation operation,
+        CancellationToken cancellationToken)
+    {
+        var newAnimationId = Guid.NewGuid();
+        await operationContext.Database.ExecuteSqlInterpolatedAsync(
+            $"""
+            INSERT INTO "Animations" ("Id", "TmdbId", "Name", "OriginalName", "PosterPath")
+            VALUES ({newAnimationId}, {operation.ProposedAnimationTmdbId}, {operation.ProposedAnimationName},
+                    {operation.ProposedAnimationOriginalName}, {operation.ProposedAnimationPosterPath})
+            ON CONFLICT ("TmdbId") DO NOTHING
+            """,
+            cancellationToken);
+        return await operationContext.Animations
+            .SingleAsync(
+                animation => animation.TmdbId == operation.ProposedAnimationTmdbId,
+                cancellationToken);
+    }
+
+    private static async Task<Models.AnimationGroup?> FindOrCreateGroupAsync(
+        Models.ApplicationContext operationContext,
+        string? proposedGroupName,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(proposedGroupName))
+            return null;
+
+        var newGroupId = Guid.NewGuid();
+        await operationContext.Database.ExecuteSqlInterpolatedAsync(
+            $"""
+            INSERT INTO "AnimationGroups" ("Id", "Name")
+            VALUES ({newGroupId}, {proposedGroupName})
+            ON CONFLICT ("Name") DO NOTHING
+            """,
+            cancellationToken);
+        return await operationContext.AnimationGroups
+            .SingleAsync(group => group.Name == proposedGroupName, cancellationToken);
+    }
+
+    private static bool MappingSetsMatch(
+        IReadOnlyList<Models.FileMapping> mappings,
+        IReadOnlyList<Models.MetadataReviewMappingSnapshot> snapshots)
+    {
+        if (mappings.Count != snapshots.Count)
+            return false;
+
+        var mappingKeys = mappings
+            .Select(mapping => new MappingKey(
+                mapping.VirtualPath,
+                mapping.PhysicalPath,
+                mapping.FileStore))
+            .OrderBy(key => key.VirtualPath, StringComparer.Ordinal)
+            .ThenBy(key => key.PhysicalPath, StringComparer.Ordinal)
+            .ThenBy(key => key.FileStore, StringComparer.Ordinal);
+        var snapshotKeys = snapshots
+            .Select(snapshot => new MappingKey(
+                snapshot.VirtualPath,
+                snapshot.PhysicalPath,
+                snapshot.FileStore))
+            .OrderBy(key => key.VirtualPath, StringComparer.Ordinal)
+            .ThenBy(key => key.PhysicalPath, StringComparer.Ordinal)
+            .ThenBy(key => key.FileStore, StringComparer.Ordinal);
+        return mappingKeys.SequenceEqual(snapshotKeys);
+    }
+
+    private static IReadOnlyList<DataFileMapping> SnapshotRecords(
+        IEnumerable<Models.MetadataReviewMappingSnapshot> snapshots,
+        MetadataReviewMappingKind kind,
+        Guid animationInfoId) =>
+        snapshots
+            .Where(snapshot => snapshot.Kind == kind)
+            .OrderBy(snapshot => snapshot.VirtualPath, StringComparer.Ordinal)
+            .Select(snapshot => new DataFileMapping(
+                snapshot.Id,
+                animationInfoId,
+                snapshot.VirtualPath,
+                snapshot.PhysicalPath,
+                snapshot.FileStore))
+            .ToList();
+
+    private static bool IsConstraintConflict(DbUpdateException exception) =>
+        exception.InnerException is PostgresException postgresException
+        && postgresException.SqlState is PostgresErrorCodes.UniqueViolation
+            or PostgresErrorCodes.ForeignKeyViolation
+            or PostgresErrorCodes.CheckViolation;
+
+    private static MetadataReviewMutationResult Failure(
+        MetadataReviewMutationOutcome outcome,
+        Guid operationId,
+        Guid? animationInfoId = null) =>
+        new(
+            outcome,
+            operationId,
+            animationInfoId,
+            null,
+            null,
+            Array.Empty<DataFileMapping>(),
+            Array.Empty<DataFileMapping>());
+
+    private sealed record CurrentOperationRow(
+        Guid Id,
+        MetadataReviewOperationState State,
+        DateTimeOffset? AppliedAt,
+        long? AppliedVersion);
+
+    private sealed record MappingKey(
+        string VirtualPath,
+        string PhysicalPath,
+        string FileStore);
+}

--- a/SecondDimensionWatcherReDive/Repositories/RepositoryConverter.cs
+++ b/SecondDimensionWatcherReDive/Repositories/RepositoryConverter.cs
@@ -26,7 +26,13 @@ internal static class RepositoryConverter
             entity.Group?.ToRecord(),
             entity.Animation?.ToRecord(),
             entity.IsAiProcessed,
-            entity.AiRetryCount);
+            entity.AiRetryCount,
+            entity.MetadataStatus,
+            entity.MetadataConfidence,
+            entity.MetadataLastError,
+            entity.MetadataReviewedAt,
+            entity.StateVersion,
+            entity.CurrentMetadataReviewOperationId);
 
     public static DataRepo.Animation ToRecord(this Models.Animation entity) =>
         new(entity.Id,
@@ -99,7 +105,13 @@ internal static class RepositoryConverter
             Season = record.Season,
             Episode = record.Episode,
             IsAiProcessed = record.IsAiProcessed,
-            AiRetryCount = record.AiRetryCount
+            AiRetryCount = record.AiRetryCount,
+            MetadataStatus = record.MetadataStatus,
+            MetadataConfidence = record.MetadataConfidence,
+            MetadataLastError = record.MetadataLastError,
+            MetadataReviewedAt = record.MetadataReviewedAt,
+            StateVersion = record.StateVersion,
+            CurrentMetadataReviewOperationId = record.CurrentMetadataReviewOperationId
         };
 
     public static Models.Animation ToEntity(this DataRepo.Animation record) =>
@@ -200,6 +212,12 @@ internal static class RepositoryConverter
         entity.Episode = record.Episode;
         entity.IsAiProcessed = record.IsAiProcessed;
         entity.AiRetryCount = record.AiRetryCount;
+        entity.MetadataStatus = record.MetadataStatus;
+        entity.MetadataConfidence = record.MetadataConfidence;
+        entity.MetadataLastError = record.MetadataLastError;
+        entity.MetadataReviewedAt = record.MetadataReviewedAt;
+        entity.StateVersion = record.StateVersion;
+        entity.CurrentMetadataReviewOperationId = record.CurrentMetadataReviewOperationId;
     }
 
     public static void ApplyTo(this DataRepo.SeasonBangumi record, Models.SeasonBangumi entity)

--- a/SecondDimensionWatcherReDive/Services/InferAnimationMetadata.cs
+++ b/SecondDimensionWatcherReDive/Services/InferAnimationMetadata.cs
@@ -17,6 +17,8 @@ public partial class InferAnimationMetadata(
     : ScheduledTaskBase
 {
     private const int MaxRetryCount = 3;
+    private const double LowConfidenceThreshold = 0.75;
+    private const int MaxErrorLength = 1024;
 
     public override string Id => "InferAnimationMetadata";
     public override TimeSpan Interval => TimeSpan.FromMinutes(30);
@@ -56,58 +58,82 @@ public partial class InferAnimationMetadata(
         IFileMapper fileMapper,
         CancellationToken cancellationToken)
     {
+        var originalItem = item;
+        var expectedStateVersion = item.StateVersion;
         try
         {
             var result = await inferenceEngine.InferAsync(
                 item.Title, item.Description, cancellationToken);
 
-            if (result != null)
+            if (result is null)
+                throw new InvalidOperationException("Inference returned no usable metadata result.");
+
+            item = originalItem with
             {
-                item = item with { Season = result.Season, Episode = result.Episode };
+                Season = result.Season,
+                Episode = result.Episode,
+                MetadataConfidence = result.Confidence
+            };
 
-                // Fetch localized name/description from TMDB
-                if (!string.IsNullOrEmpty(result.TmdbId) && int.TryParse(result.TmdbId, out var tmdbIdInt))
+            // Fetch localized name/description from TMDB
+            if (!string.IsNullOrEmpty(result.TmdbId) && int.TryParse(result.TmdbId, out var tmdbIdInt))
+            {
+                var details = await tmdbTool.GetLocalizedDetailsAsync(tmdbIdInt, cancellationToken);
+
+                if (details != null && !string.IsNullOrEmpty(details.Overview))
+                    item = item with { Description = details.Overview };
+
+                var animation = await animationRepository
+                    .FindByTmdbIdAsync(result.TmdbId, cancellationToken);
+
+                if (animation == null)
                 {
-                    var details = await tmdbTool.GetLocalizedDetailsAsync(tmdbIdInt, cancellationToken);
-
-                    if (details != null && !string.IsNullOrEmpty(details.Overview))
-                        item = item with { Description = details.Overview };
-
-                    var animation = await animationRepository
-                        .FindByTmdbIdAsync(result.TmdbId, cancellationToken);
-
-                    if (animation == null)
-                    {
-                        animation = new Animation(
-                            Guid.NewGuid(),
-                            result.TmdbId,
-                            details?.Name ?? result.TmdbId,
-                            details?.OriginalName ?? "",
-                            details?.PosterPath);
-                        await animationRepository.AddAsync(animation, cancellationToken);
-                    }
-
-                    item = item with { Animation = animation };
+                    animation = new Animation(
+                        Guid.NewGuid(),
+                        result.TmdbId,
+                        details?.Name ?? result.TmdbId,
+                        details?.OriginalName ?? "",
+                        details?.PosterPath);
+                    await animationRepository.AddAsync(animation, cancellationToken);
                 }
 
-                // Resolve or create AnimationGroup
-                if (!string.IsNullOrEmpty(result.GroupName))
-                {
-                    var group = await animationGroupRepository
-                        .FindByNameAsync(result.GroupName, cancellationToken);
-
-                    if (group == null)
-                    {
-                        group = new AnimationGroup(Guid.NewGuid(), result.GroupName);
-                        await animationGroupRepository.AddAsync(group, cancellationToken);
-                    }
-
-                    item = item with { Group = group };
-                }
+                item = item with { Animation = animation };
             }
 
-            item = item with { IsAiProcessed = true };
-            await animationInfoRepository.UpdateAsync(item, cancellationToken);
+            // Resolve or create AnimationGroup
+            if (!string.IsNullOrEmpty(result.GroupName))
+            {
+                var group = await animationGroupRepository
+                    .FindByNameAsync(result.GroupName, cancellationToken);
+
+                if (group == null)
+                {
+                    group = new AnimationGroup(Guid.NewGuid(), result.GroupName);
+                    await animationGroupRepository.AddAsync(group, cancellationToken);
+                }
+
+                item = item with { Group = group };
+            }
+
+            var confidence = result.Confidence ?? 0;
+            item = item with
+            {
+                IsAiProcessed = true,
+                AiRetryCount = 0,
+                MetadataStatus = confidence < LowConfidenceThreshold
+                    ? MetadataReviewStatus.LowConfidence
+                    : MetadataReviewStatus.Identified,
+                MetadataLastError = null,
+                MetadataReviewedAt = null
+            };
+            if (!await animationInfoRepository.TryUpdateAsync(
+                    item,
+                    expectedStateVersion,
+                    cancellationToken))
+            {
+                LogStaleInferenceDiscarded(logger, item.Id);
+                return;
+            }
 
             LogInferenceCompleted(logger, item.Id, item.Title);
 
@@ -132,8 +158,30 @@ public partial class InferAnimationMetadata(
         }
         catch (Exception ex)
         {
-            item = item with { AiRetryCount = item.AiRetryCount + 1 };
-            await animationInfoRepository.UpdateAsync(item, cancellationToken);
+            var retryCount = item.AiRetryCount + 1;
+            var error = string.IsNullOrWhiteSpace(ex.Message)
+                ? ex.GetType().Name
+                : ex.Message;
+            if (error.Length > MaxErrorLength) error = error[..MaxErrorLength];
+            item = originalItem with
+            {
+                IsAiProcessed = false,
+                AiRetryCount = retryCount,
+                MetadataStatus = retryCount >= MaxRetryCount
+                    ? MetadataReviewStatus.Failed
+                    : MetadataReviewStatus.Pending,
+                MetadataConfidence = null,
+                MetadataLastError = error,
+                MetadataReviewedAt = null
+            };
+            if (!await animationInfoRepository.TryUpdateAsync(
+                    item,
+                    expectedStateVersion,
+                    cancellationToken))
+            {
+                LogStaleInferenceDiscarded(logger, item.Id);
+                return;
+            }
 
             LogInferenceFailed(logger, ex, item.Id, item.Title, item.AiRetryCount, MaxRetryCount);
         }
@@ -150,4 +198,8 @@ public partial class InferAnimationMetadata(
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Re-mapping files after inference failed for AnimationInfo {Id}")]
     private static partial void LogRemapFailed(ILogger logger, Exception ex, Guid id);
+
+    [LoggerMessage(Level = LogLevel.Information,
+        Message = "Discarded stale AI inference result for AnimationInfo {Id} because metadata changed concurrently")]
+    private static partial void LogStaleInferenceDiscarded(ILogger logger, Guid id);
 }

--- a/SecondDimensionWatcherReDive/Utils/FileStore/FileMapper.cs
+++ b/SecondDimensionWatcherReDive/Utils/FileStore/FileMapper.cs
@@ -9,7 +9,15 @@ public interface IFileMapper
     Task MapDownloadAsync(Guid animationInfoId, CancellationToken cancellationToken);
 
     Task<bool> ReidentifyFilesWithAiAsync(Guid animationInfoId, CancellationToken cancellationToken);
+
+    Task<FileMappingPreview?> PreviewDownloadAsync(
+        AnimationInfo proposedInfo,
+        CancellationToken cancellationToken);
 }
+
+public sealed record FileMappingPreview(
+    IReadOnlyList<FileMapping> Mappings,
+    IReadOnlyList<string> Warnings);
 
 internal sealed class AiFileNameInferenceUnavailableException()
     : InvalidOperationException("AI filename inference is not configured.")
@@ -51,6 +59,29 @@ public partial class FileMapper(
         return MapDownloadCoreAsync(animationInfoId, true, cancellationToken);
     }
 
+    public async Task<FileMappingPreview?> PreviewDownloadAsync(
+        AnimationInfo proposedInfo,
+        CancellationToken cancellationToken)
+    {
+        var warnings = new List<string>();
+        var mappings = await PlanDownloadAsync(
+            proposedInfo,
+            forceAi: false,
+            allowAi: false,
+            warnings,
+            cancellationToken);
+        if (mappings is null) return null;
+
+        if (mappings.Any(mapping => mapping.VirtualPath.StartsWith(
+                UnknownRoot + "/",
+                StringComparison.Ordinal)))
+            warnings.Add("unresolvedFiles");
+
+        return new FileMappingPreview(
+            mappings,
+            warnings.Distinct(StringComparer.Ordinal).ToList());
+    }
+
     private async Task<bool> MapDownloadCoreAsync(
         Guid animationInfoId,
         bool forceAi,
@@ -63,32 +94,18 @@ public partial class FileMapper(
             return false;
         }
 
-        if (info.FileStore is null || info.StorePath is null)
-        {
-            LogNoStorePath(logger, animationInfoId);
-            return false;
-        }
-
-        var store = fileStoreProvider.GetClient(info.FileStore);
-        if (store is null)
-        {
-            LogNoFileStore(logger, info.FileStore);
-            return false;
-        }
-
-        var files = await EnumerateFilesAsync(store, info.StorePath, cancellationToken);
-        if (files.Count == 0)
-        {
-            LogNoFiles(logger, info.StorePath);
-            return false;
-        }
-
-        var mappings = await BuildMappingsAsync(info, files, forceAi, cancellationToken);
+        var mappings = await PlanDownloadAsync(
+            info,
+            forceAi,
+            allowAi: true,
+            warnings: null,
+            cancellationToken);
+        if (mappings is null) return false;
         if (mappings.Count == 0) return false;
 
         // A manual AI-only retry is all-or-nothing. Partial results must not replace a
         // previously complete mapping and move the unresolved episodes to /unknown.
-        if (forceAi && !AllVideoFilesIdentified(files, mappings))
+        if (forceAi && !AllVideoFilesIdentified(mappings))
         {
             LogForcedInferenceNoResult(logger, animationInfoId);
             return false;
@@ -99,8 +116,9 @@ public partial class FileMapper(
         // collide with the unique VirtualPath index.
         var replaced = await fileMappingRepository.ReplaceForAnimationInfoAsync(
             info.Id,
-            info.FileStore,
-            info.StorePath,
+            info.StateVersion,
+            info.FileStore!,
+            info.StorePath!,
             mappings,
             cancellationToken);
         if (!replaced)
@@ -112,21 +130,53 @@ public partial class FileMapper(
         return true;
     }
 
+    private async Task<List<FileMapping>?> PlanDownloadAsync(
+        AnimationInfo info,
+        bool forceAi,
+        bool allowAi,
+        List<string>? warnings,
+        CancellationToken cancellationToken)
+    {
+        if (info.FileStore is null || info.StorePath is null)
+        {
+            LogNoStorePath(logger, info.Id);
+            return null;
+        }
+
+        var store = fileStoreProvider.GetClient(info.FileStore);
+        if (store is null)
+        {
+            LogNoFileStore(logger, info.FileStore);
+            return null;
+        }
+
+        var files = await EnumerateFilesAsync(store, info.StorePath, cancellationToken);
+        if (files.Count == 0)
+        {
+            LogNoFiles(logger, info.StorePath);
+            return null;
+        }
+
+        return await BuildMappingsAsync(
+            info,
+            files,
+            forceAi,
+            allowAi,
+            warnings,
+            cancellationToken);
+    }
+
     private static bool AllVideoFilesIdentified(
-        IReadOnlyList<DiscoveredFile> files,
         IReadOnlyList<FileMapping> mappings)
     {
-        var videos = files
-            .Where(file => VideoExtensions.Contains(Path.GetExtension(file.FileName)))
+        var videos = mappings
+            .Where(mapping => VideoExtensions.Contains(Path.GetExtension(mapping.PhysicalPath)))
             .ToList();
         if (videos.Count == 0) return false;
 
         foreach (var video in videos)
         {
-            var mapping = mappings.FirstOrDefault(candidate =>
-                candidate.PhysicalPath == video.PhysicalPath);
-            if (mapping is null
-                || mapping.VirtualPath.StartsWith(UnknownRoot + "/", StringComparison.Ordinal))
+            if (video.VirtualPath.StartsWith(UnknownRoot + "/", StringComparison.Ordinal))
                 return false;
         }
 
@@ -140,7 +190,9 @@ public partial class FileMapper(
     {
         var result = new List<DiscoveredFile>();
         await WalkAsync(store, rootPath, "", result, cancellationToken);
-        return result;
+        return result
+            .OrderBy(file => file.RelativePath, StringComparer.Ordinal)
+            .ToList();
 
         static async Task WalkAsync(
             IFileStore store, string path, string relativeBase,
@@ -164,6 +216,8 @@ public partial class FileMapper(
         AnimationInfo info,
         List<DiscoveredFile> files,
         bool forceAi,
+        bool allowAi,
+        List<string>? warnings,
         CancellationToken cancellationToken)
     {
         var mappings = new List<FileMapping>();
@@ -186,7 +240,7 @@ public partial class FileMapper(
                 var virtualPath = $"{UnknownRoot}/{file.RelativePath}";
                 AddMapping(mappings, reservedPaths, info, file, virtualPath, cancellationToken);
             }
-            return await ResolveCollisionsAsync(mappings, cancellationToken);
+            return await ResolveCollisionsAsync(mappings, warnings, cancellationToken);
         }
 
         var videos = files.Where(f => VideoExtensions.Contains(Path.GetExtension(f.FileName))).ToList();
@@ -202,7 +256,7 @@ public partial class FileMapper(
                 foreach (var file in files)
                     AddMapping(mappings, reservedPaths, info, file,
                         $"{UnknownRoot}/{file.RelativePath}", cancellationToken);
-                return await ResolveCollisionsAsync(mappings, cancellationToken);
+                return await ResolveCollisionsAsync(mappings, warnings, cancellationToken);
             }
 
             var mainVideo = videos.Count == 1
@@ -234,12 +288,17 @@ public partial class FileMapper(
                 AddMapping(mappings, reservedPaths, info, file,
                     $"{UnknownRoot}/{file.RelativePath}", cancellationToken);
 
-            return await ResolveCollisionsAsync(mappings, cancellationToken);
+            return await ResolveCollisionsAsync(mappings, warnings, cancellationToken);
         }
 
         // Case 3: known multi-episode — resolve the whole video batch. Stored rules
         // run first during normal mapping; only unresolved files are sent to AI.
-        var inferredFiles = await InferVideoFilesAsync(info, videos, forceAi, cancellationToken);
+        var inferredFiles = await InferVideoFilesAsync(
+            info,
+            videos,
+            forceAi,
+            allowAi,
+            cancellationToken);
         var matchedSubs = new HashSet<DiscoveredFile>();
         foreach (var video in videos)
         {
@@ -273,13 +332,14 @@ public partial class FileMapper(
             AddMapping(mappings, reservedPaths, info, file,
                 $"{UnknownRoot}/{file.RelativePath}", cancellationToken);
 
-        return await ResolveCollisionsAsync(mappings, cancellationToken);
+        return await ResolveCollisionsAsync(mappings, warnings, cancellationToken);
     }
 
     private async Task<Dictionary<string, FileNameInferenceResult>> InferVideoFilesAsync(
         AnimationInfo info,
         IReadOnlyList<DiscoveredFile> videos,
         bool forceAi,
+        bool allowAi,
         CancellationToken cancellationToken)
     {
         var inputs = videos
@@ -294,7 +354,7 @@ public partial class FileMapper(
             .Where(input => !results.ContainsKey(input.FilePath))
             .ToList();
 
-        if (unresolved.Count > 0 && inferenceEngine is not null)
+        if (allowAi && unresolved.Count > 0 && inferenceEngine is not null)
         {
             var aiResults = await inferenceEngine.InferFileNamesAsync(
                 new FileNameInferenceRequest(
@@ -393,7 +453,9 @@ public partial class FileMapper(
     }
 
     private async Task<List<FileMapping>> ResolveCollisionsAsync(
-        List<FileMapping> mappings, CancellationToken cancellationToken)
+        List<FileMapping> mappings,
+        List<string>? warnings,
+        CancellationToken cancellationToken)
     {
         var result = new List<FileMapping>(mappings.Count);
         var taken = new HashSet<string>(StringComparer.Ordinal);
@@ -405,6 +467,8 @@ public partial class FileMapper(
                        mapping.AnimationInfoId,
                        cancellationToken))
                 path = NextSuffixed(path);
+            if (!string.Equals(path, mapping.VirtualPath, StringComparison.Ordinal))
+                warnings?.Add("collisionAdjusted");
             taken.Add(path);
             result.Add(mapping with { VirtualPath = path });
         }

--- a/SecondDimensionWatcherReDive/Utils/MetadataReview/MetadataReviewService.cs
+++ b/SecondDimensionWatcherReDive/Utils/MetadataReview/MetadataReviewService.cs
@@ -1,0 +1,380 @@
+using System.Text.RegularExpressions;
+using SecondDimensionWatcherReDive.Framework.DataRepository;
+using SecondDimensionWatcherReDive.Inference.AI.Tools;
+using SecondDimensionWatcherReDive.Utils.FileStore;
+
+namespace SecondDimensionWatcherReDive.Utils.MetadataReview;
+
+public interface IMetadataReviewService
+{
+    Task<MetadataReviewPreviewResult> PreviewAsync(
+        Guid animationInfoId,
+        long expectedRevision,
+        MetadataReviewCorrection correction,
+        CancellationToken cancellationToken);
+
+    Task<MetadataReviewChangeResult> ApplyAsync(
+        Guid animationInfoId,
+        Guid previewId,
+        CancellationToken cancellationToken);
+
+    Task<MetadataReviewChangeResult> UndoAsync(
+        Guid operationId,
+        long expectedRevision,
+        CancellationToken cancellationToken);
+}
+
+public sealed record MetadataReviewCorrection(
+    string? TmdbId,
+    int? Season,
+    int? Episode,
+    string? GroupName);
+
+public sealed record MetadataReviewResolvedMetadata(
+    string TmdbId,
+    string Name,
+    string OriginalName,
+    string? PosterPath,
+    int Season,
+    int? Episode,
+    string? GroupName);
+
+public sealed record MetadataReviewPathChange(
+    string FileName,
+    string? CurrentVirtualPath,
+    string? ProposedVirtualPath,
+    string ChangeKind,
+    bool CollisionAdjusted);
+
+public sealed record MetadataReviewPreviewResult(
+    Guid PreviewId,
+    long BaseRevision,
+    MetadataReviewResolvedMetadata ResolvedMetadata,
+    IReadOnlyList<MetadataReviewPathChange> PathChanges,
+    IReadOnlyList<string> Warnings,
+    bool CanApply,
+    DateTimeOffset ExpiresAt);
+
+public sealed record MetadataReviewChangeResult(
+    Guid OperationId,
+    long Revision,
+    IReadOnlyList<MetadataReviewPathChange> PathChanges,
+    DateTimeOffset AppliedAt,
+    bool CanUndo);
+
+public abstract class MetadataReviewServiceException(string code, string message)
+    : Exception(message)
+{
+    public string Code { get; } = code;
+}
+
+public sealed class MetadataReviewNotFoundException(string code, string message)
+    : MetadataReviewServiceException(code, message);
+
+public sealed class MetadataReviewConflictException(string code, string message)
+    : MetadataReviewServiceException(code, message);
+
+public sealed class MetadataReviewValidationException(string code, string message)
+    : MetadataReviewServiceException(code, message);
+
+public sealed class MetadataReviewUnavailableException(string code, string message)
+    : MetadataReviewServiceException(code, message);
+
+public sealed partial class MetadataReviewService(
+    IAnimationInfoRepository animationInfoRepository,
+    IAnimationRepository animationRepository,
+    IAnimationGroupRepository animationGroupRepository,
+    IFileMappingRepository fileMappingRepository,
+    IMetadataReviewRepository metadataReviewRepository,
+    IFileMapper fileMapper,
+    TmdbTool tmdbTool) : IMetadataReviewService
+{
+    private static readonly TimeSpan PreviewLifetime = TimeSpan.FromMinutes(15);
+    private const int MaxGroupNameLength = 200;
+
+    public async Task<MetadataReviewPreviewResult> PreviewAsync(
+        Guid animationInfoId,
+        long expectedRevision,
+        MetadataReviewCorrection correction,
+        CancellationToken cancellationToken)
+    {
+        var current = await animationInfoRepository.FindByIdWithAnimationAsync(
+            animationInfoId,
+            cancellationToken);
+        if (current is null)
+            throw new MetadataReviewNotFoundException("itemNotFound", "The metadata item was not found.");
+        if (current.StateVersion != expectedRevision)
+            throw new MetadataReviewConflictException(
+                "staleRevision",
+                "The item changed after it was loaded. Refresh it before previewing again.");
+
+        var tmdbId = ValidateTmdbId(correction.TmdbId);
+        var season = correction.Season
+                     ?? throw new MetadataReviewValidationException(
+                         "seasonRequired",
+                         "A TMDB season is required.");
+        if (season < 0)
+            throw new MetadataReviewValidationException("invalidSeason", "Season cannot be negative.");
+        if (correction.Episode is < 0)
+            throw new MetadataReviewValidationException("invalidEpisode", "Episode cannot be negative.");
+
+        var groupName = NormalizeGroupName(correction.GroupName);
+        var animation = await ResolveAnimationAsync(tmdbId, cancellationToken);
+        var group = groupName is null
+            ? null
+            : await animationGroupRepository.FindByNameAsync(groupName, cancellationToken)
+              ?? new AnimationGroup(Guid.NewGuid(), groupName);
+
+        var proposed = current with
+        {
+            Animation = animation,
+            Group = group,
+            Season = season,
+            Episode = correction.Episode,
+            IsAiProcessed = true,
+            AiRetryCount = 0,
+            MetadataStatus = MetadataReviewStatus.Reviewed,
+            MetadataConfidence = 1,
+            MetadataLastError = null,
+            MetadataReviewedAt = DateTimeOffset.UtcNow
+        };
+
+        var currentMappings = await fileMappingRepository.GetForAnimationInfoAsync(
+            animationInfoId,
+            cancellationToken);
+        IReadOnlyList<FileMapping> proposedMappings;
+        var warnings = new List<string>();
+        if (current.IsDownloadFinished)
+        {
+            if (current.FileStore is null || current.StorePath is null)
+                throw new MetadataReviewConflictException(
+                    "downloadLocationMissing",
+                    "The downloaded item no longer has a valid storage location.");
+
+            var preview = await fileMapper.PreviewDownloadAsync(proposed, cancellationToken);
+            if (preview is null)
+                throw new MetadataReviewUnavailableException(
+                    "mappingUnavailable",
+                    "The downloaded files could not be enumerated for path preview.");
+            proposedMappings = preview.Mappings;
+            warnings.AddRange(preview.Warnings);
+        }
+        else
+        {
+            // A metadata-only correction must not unexpectedly delete mappings if an
+            // inconsistent legacy row happens to have them before download completion.
+            proposedMappings = currentMappings;
+            warnings.Add("notDownloaded");
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var operationId = Guid.NewGuid();
+        var expiresAt = now.Add(PreviewLifetime);
+        var proposedDescription = await ResolveDescriptionAsync(
+            tmdbId,
+            animation,
+            current.Description,
+            cancellationToken);
+        await metadataReviewRepository.SavePreviewAsync(
+            new MetadataReviewPreviewDraft(
+                operationId,
+                animationInfoId,
+                current.StateVersion,
+                current.FileStore,
+                current.StorePath,
+                current.IsDownloadFinished,
+                animation,
+                proposedDescription,
+                season,
+                correction.Episode,
+                groupName,
+                now,
+                expiresAt,
+                proposedMappings),
+            cancellationToken);
+
+        return new MetadataReviewPreviewResult(
+            operationId,
+            current.StateVersion,
+            new MetadataReviewResolvedMetadata(
+                animation.TmdbId,
+                animation.Name,
+                animation.OriginalName,
+                animation.PosterPath,
+                season,
+                correction.Episode,
+                groupName),
+            BuildPathChanges(currentMappings, proposedMappings),
+            warnings.Distinct(StringComparer.Ordinal).ToList(),
+            true,
+            expiresAt);
+    }
+
+    public async Task<MetadataReviewChangeResult> ApplyAsync(
+        Guid animationInfoId,
+        Guid previewId,
+        CancellationToken cancellationToken)
+    {
+        var result = await metadataReviewRepository.ApplyPreviewAsync(
+            previewId,
+            animationInfoId,
+            cancellationToken);
+        return ToChangeResult(result, applying: true);
+    }
+
+    public async Task<MetadataReviewChangeResult> UndoAsync(
+        Guid operationId,
+        long expectedRevision,
+        CancellationToken cancellationToken)
+    {
+        var result = await metadataReviewRepository.UndoAsync(
+            operationId,
+            expectedRevision,
+            cancellationToken);
+        return ToChangeResult(result, applying: false);
+    }
+
+    private async Task<Animation> ResolveAnimationAsync(
+        string tmdbId,
+        CancellationToken cancellationToken)
+    {
+        var existing = await animationRepository.FindByTmdbIdAsync(tmdbId, cancellationToken);
+        if (existing is not null) return existing;
+
+        if (!tmdbTool.IsConfigured)
+            throw new MetadataReviewUnavailableException(
+                "tmdbUnavailable",
+                "TMDB lookup is unavailable because no API key is configured.");
+
+        var details = await tmdbTool.GetLocalizedDetailsAsync(
+            int.Parse(tmdbId, System.Globalization.CultureInfo.InvariantCulture),
+            cancellationToken);
+        if (details is null || string.IsNullOrWhiteSpace(details.Name))
+            throw new MetadataReviewValidationException(
+                "tmdbNotFound",
+                "The TMDB television series could not be resolved.");
+
+        return new Animation(
+            Guid.NewGuid(),
+            tmdbId,
+            details.Name,
+            details.OriginalName,
+            details.PosterPath);
+    }
+
+    private async Task<string> ResolveDescriptionAsync(
+        string tmdbId,
+        Animation animation,
+        string fallback,
+        CancellationToken cancellationToken)
+    {
+        // Existing Animation records do not retain the localized overview, so resolve it
+        // here as part of the preview. A failed optional lookup keeps the current text.
+        var details = await tmdbTool.GetLocalizedDetailsAsync(
+            int.Parse(tmdbId, System.Globalization.CultureInfo.InvariantCulture),
+            cancellationToken);
+        _ = animation;
+        return string.IsNullOrWhiteSpace(details?.Overview) ? fallback : details.Overview;
+    }
+
+    private static MetadataReviewChangeResult ToChangeResult(
+        MetadataReviewMutationResult result,
+        bool applying)
+    {
+        switch (result.Outcome)
+        {
+            case MetadataReviewMutationOutcome.NotFound:
+                throw new MetadataReviewNotFoundException(
+                    "operationNotFound",
+                    "The metadata review operation was not found.");
+            case MetadataReviewMutationOutcome.Expired:
+                throw new MetadataReviewConflictException(
+                    "previewExpired",
+                    "The path preview expired. Create a fresh preview before applying it.");
+            case MetadataReviewMutationOutcome.Conflict:
+                throw new MetadataReviewConflictException(
+                    applying ? "stalePreview" : "undoConflict",
+                    applying
+                        ? "The item or its virtual paths changed after preview. Preview it again."
+                        : "This operation can no longer be undone because the item changed.");
+            case MetadataReviewMutationOutcome.Success:
+                break;
+            default:
+                throw new InvalidOperationException($"Unknown metadata mutation outcome: {result.Outcome}");
+        }
+
+        if (result.Revision is null || result.AppliedAt is null)
+            throw new InvalidOperationException("A successful metadata review mutation returned no revision.");
+
+        return new MetadataReviewChangeResult(
+            result.OperationId,
+            result.Revision.Value,
+            BuildPathChanges(result.MappingsBefore, result.MappingsAfter),
+            result.AppliedAt.Value,
+            applying);
+    }
+
+    private static IReadOnlyList<MetadataReviewPathChange> BuildPathChanges(
+        IReadOnlyList<FileMapping> before,
+        IReadOnlyList<FileMapping> after)
+    {
+        var currentByPhysicalPath = before
+            .GroupBy(mapping => mapping.PhysicalPath, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+        var proposedByPhysicalPath = after
+            .GroupBy(mapping => mapping.PhysicalPath, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+        var physicalPaths = currentByPhysicalPath.Keys
+            .Concat(proposedByPhysicalPath.Keys)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(path => path, StringComparer.Ordinal);
+
+        var changes = new List<MetadataReviewPathChange>();
+        foreach (var physicalPath in physicalPaths)
+        {
+            currentByPhysicalPath.TryGetValue(physicalPath, out var current);
+            proposedByPhysicalPath.TryGetValue(physicalPath, out var proposed);
+            var kind = current is null
+                ? "added"
+                : proposed is null
+                    ? "removed"
+                    : string.Equals(current.VirtualPath, proposed.VirtualPath, StringComparison.Ordinal)
+                        ? "unchanged"
+                        : "moved";
+            changes.Add(new MetadataReviewPathChange(
+                Path.GetFileName(physicalPath),
+                current?.VirtualPath,
+                proposed?.VirtualPath,
+                kind,
+                proposed is not null && CollisionSuffixRegex().IsMatch(proposed.VirtualPath)));
+        }
+
+        return changes;
+    }
+
+    private static string ValidateTmdbId(string? value)
+    {
+        var normalized = value?.Trim();
+        if (string.IsNullOrEmpty(normalized)
+            || !int.TryParse(normalized, out var parsed)
+            || parsed <= 0)
+            throw new MetadataReviewValidationException(
+                "invalidTmdbId",
+                "TMDB ID must be a positive integer.");
+        return parsed.ToString(System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static string? NormalizeGroupName(string? value)
+    {
+        var normalized = value?.Trim();
+        if (string.IsNullOrEmpty(normalized)) return null;
+        if (normalized.Length > MaxGroupNameLength)
+            throw new MetadataReviewValidationException(
+                "groupNameTooLong",
+                $"Subtitle group cannot exceed {MaxGroupNameLength} characters.");
+        return normalized;
+    }
+
+    [GeneratedRegex(@" \(\d+\)(?=\.[^/]+$|$)", RegexOptions.CultureInvariant)]
+    private static partial Regex CollisionSuffixRegex();
+}


### PR DESCRIPTION
## Summary

- add pending, low-confidence, and failed metadata review queues with localized SPA workflows
- support manual TMDB, season, episode, and subtitle-group corrections with virtual-path previews
- atomically apply metadata and mapping changes with PostgreSQL locks, optimistic revisions, durable snapshots, idempotent retries, and stack-style undo
- track inference confidence and failure details while preventing stale AI results from overwriting manual reviews
- add schema migration, REST API, mock-server support, and regression coverage

## Validation

- `dotnet test SecondDimensionWatcherReDive.slnx --no-restore` — 164 unit tests and 65 integration tests passed
- `yarn build` — production frontend build passed
- `git diff --check` passed
- applied the migration and exercised list → preview → apply → undo against a real PostgreSQL instance; metadata, revisions, mappings, and operation state were restored correctly
