### PR TITLE
Validate torrent payload size before automatic downloads

### DIFF
--- a/SecondDimensionWatcherReDive.Test/SyncFeedTests.cs
+++ b/SecondDimensionWatcherReDive.Test/SyncFeedTests.cs
@@ -1,7 +1,9 @@
 using System.Reflection;
+using BencodeNET.Objects;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
+using SecondDimensionWatcherReDive.Exceptions;
 using SecondDimensionWatcherReDive.Framework.Feed;
 using SecondDimensionWatcherReDive.Framework.FileDownload;
 using SecondDimensionWatcherReDive.Framework.DataRepository;
@@ -254,6 +256,44 @@ public class SyncFeedTests
             SubscriptionAutomationDisposition.AutoDownloadFailed,
             It.Is<CancellationToken>(token =>
                 token.CanBeCanceled && !token.IsCancellationRequested)), Times.Once);
+    }
+
+    [TestMethod]
+    public void GetTorrentPayloadSize_MultiFileTorrent_ReturnsCheckedAggregate()
+    {
+        var first = new BDictionary();
+        first.Add("length", 1_500L);
+        var second = new BDictionary();
+        second.Add("length", 2_500L);
+        var files = new BList([first, second]);
+        var info = new BDictionary { ["files"] = files };
+
+        var size = InvokeGetTorrentPayloadSize(info);
+
+        Assert.AreEqual(4_000L, size);
+    }
+
+    [TestMethod]
+    public void GetTorrentPayloadSize_OverflowingAggregate_RejectsTorrent()
+    {
+        var first = new BDictionary();
+        first.Add("length", long.MaxValue);
+        var second = new BDictionary();
+        second.Add("length", 1L);
+        var info = new BDictionary { ["files"] = new BList([first, second]) };
+
+        var exception = Assert.ThrowsExactly<TargetInvocationException>(
+            () => InvokeGetTorrentPayloadSize(info));
+
+        Assert.IsInstanceOfType<InvalidTorrentDataException>(exception.InnerException);
+    }
+
+    private static long InvokeGetTorrentPayloadSize(BDictionary info)
+    {
+        var method = typeof(SyncFeed).GetMethod(
+            "GetTorrentPayloadSize",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (long)method.Invoke(null, [info, "https://example.com/release.torrent"])!;
     }
 
     private void SetupNewPolicyRequest(AnimationAddRequest request, SubscriptionAutomationPolicy policy)

--- a/SecondDimensionWatcherReDive/Exceptions/InvalidTorrentDataException.cs
+++ b/SecondDimensionWatcherReDive/Exceptions/InvalidTorrentDataException.cs
@@ -1,3 +1,4 @@
 namespace SecondDimensionWatcherReDive.Exceptions;
 
-public class InvalidTorrentDataException(string url) : Exception($"{url} seems to be empty data.");
+public class InvalidTorrentDataException(string url, string reason = "torrent data is empty")
+    : Exception($"Invalid torrent data from {url}: {reason}.");

--- a/SecondDimensionWatcherReDive/Services/SyncFeed.cs
+++ b/SecondDimensionWatcherReDive/Services/SyncFeed.cs
@@ -35,7 +35,7 @@ public partial class SyncFeed(
         await Task.WhenAll(feeds.Select(f => ProcessFeed(f, cancellationToken)));
     }
 
-    private readonly record struct TorrentData(byte[] CachedDownloadData, string Hash);
+    private readonly record struct TorrentData(byte[] CachedDownloadData, string Hash, long? PayloadSizeBytes);
 
     private async Task<TorrentData> DownloadTorrentData(
         AnimationAddRequest request,
@@ -47,13 +47,58 @@ public partial class SyncFeed(
             throw new InvalidTorrentDataException(request.DownloadUrl);
         }
         var parser = new BencodeParser();
+        BDictionary info;
+        try
+        {
+            info = parser.Parse<BDictionary>(data).Get<BDictionary>("info")
+                ?? throw new InvalidTorrentDataException(request.DownloadUrl, "info dictionary is missing");
+        }
+        catch (InvalidTorrentDataException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            throw new InvalidTorrentDataException(request.DownloadUrl, exception.Message);
+        }
+
+        var payloadSize = GetTorrentPayloadSize(info, request.DownloadUrl);
         var hash = BitConverter
             .ToString(SHA1.HashData(
-                parser.Parse<BDictionary>(data)["info"]
-                    .EncodeAsBytes()))
+                info.EncodeAsBytes()))
             .Replace("-", "")
             .ToLower();
-        return new TorrentData(data, hash);
+        return new TorrentData(data, hash, payloadSize);
+    }
+
+    private static long GetTorrentPayloadSize(BDictionary info, string url)
+    {
+        var singleFileLength = info.Get<BNumber>("length");
+        var files = info.Get<BList>("files");
+        if ((singleFileLength is null) == (files is null))
+            throw new InvalidTorrentDataException(url, "info must contain either length or files");
+
+        try
+        {
+            if (singleFileLength is not null)
+                return singleFileLength.Value >= 0
+                    ? singleFileLength.Value
+                    : throw new InvalidTorrentDataException(url, "payload length is negative");
+
+            long total = 0;
+            foreach (var item in files!.Value)
+            {
+                var length = (item as BDictionary)?.Get<BNumber>("length")?.Value;
+                if (length is null || length < 0)
+                    throw new InvalidTorrentDataException(url, "file length is missing or negative");
+                total = checked(total + length.Value);
+            }
+            return total;
+        }
+        catch (OverflowException)
+        {
+            throw new InvalidTorrentDataException(url, "aggregate payload length exceeds supported limits");
+        }
     }
 
     private async Task ProcessSingle(AnimationAddRequest request, CancellationToken cancellationToken)
@@ -67,25 +112,33 @@ public partial class SyncFeed(
             try
             {
                 SubscriptionAutomationPolicy? policy = null;
-                SubscriptionAutomationEvaluation? evaluation = null;
                 if (request.FeedId is { } feedId)
                 {
                     var policyRepository = scope.ServiceProvider
                         .GetRequiredService<ISubscriptionAutomationPolicyRepository>();
                     policy = await policyRepository.FindByFeedIdAsync(feedId, cancellationToken);
-                    if (policy is not null)
-                    {
-                        evaluation = automationMatcher.Evaluate(policy, request);
-                        if (!evaluation.Matched)
-                            return;
-                    }
                 }
 
                 var torrentData = request.DownloadType switch
                 {
                     FileDownloadTypes.TorrentDownload => await DownloadTorrentData(request, cancellationToken),
-                    _ => new TorrentData(Array.Empty<byte>(), request.AdditionalDownloadInfo)
+                    _ => new TorrentData(Array.Empty<byte>(), request.AdditionalDownloadInfo, request.ContentLength)
                 };
+
+                if (request.DownloadType == FileDownloadTypes.TorrentDownload &&
+                    request.ContentLength is { } advertisedSize &&
+                    advertisedSize != torrentData.PayloadSizeBytes)
+                    throw new InvalidTorrentDataException(request.DownloadUrl, "advertised and declared payload sizes differ");
+
+                SubscriptionAutomationEvaluation? evaluation = null;
+                if (policy is not null)
+                {
+                    evaluation = automationMatcher.Evaluate(
+                        policy,
+                        request with { ContentLength = torrentData.PayloadSizeBytes });
+                    if (!evaluation.Matched)
+                        return;
+                }
 
                 var info = new AnimationInfo(
                     Guid.NewGuid(),
@@ -109,7 +162,7 @@ public partial class SyncFeed(
                     IsAiProcessed: false,
                     AiRetryCount: 0,
                     SourceFeedId: request.FeedId,
-                    ReleaseSizeBytes: evaluation?.Metadata.SizeBytes ?? request.ContentLength,
+                    ReleaseSizeBytes: torrentData.PayloadSizeBytes,
                     AutomationDisposition: policy?.Mode switch
                     {
                         SubscriptionAutomationMode.NotifyOnly => SubscriptionAutomationDisposition.Notified,


### PR DESCRIPTION
### Motivation

- Prevent attackers from bypassing subscription size caps by advertising a smaller `torrent:contentLength` in RSS while the torrent's bencoded `info` declares a much larger payload, which could cause automatic queuing of arbitrarily large torrents.

### Description

- Parse the authoritative torrent-declared payload size from the bencoded `info` dictionary and compute either the single-file `info.length` or the checked aggregate of `info.files[].length` in `Services/SyncFeed.cs` via a new `GetTorrentPayloadSize` helper and extend the `TorrentData` record with `PayloadSizeBytes`.
- Reject malformed, negative, ambiguous, or overflowing payload declarations and surface diagnostics via an enhanced `InvalidTorrentDataException` that includes the source URL and reason (`Exceptions/InvalidTorrentDataException.cs`).
- Compare the RSS-advertised `ContentLength` against the parsed torrent payload size and reject mismatches; re-evaluate subscription automation policies using the declared torrent payload size and persist `ReleaseSizeBytes` from the validated payload instead of trusting RSS metadata (`Services/SyncFeed.cs`).
- Add regression unit tests to cover multi-file aggregation and overflow rejection in `SecondDimensionWatcherReDive.Test/SyncFeedTests.cs` and add the necessary test imports.

### Testing

- Ran repository checks (`git diff --check`) and committed the change as `fix: validate torrent payload size before automation`; static diffs are clean.
- Added unit tests (`SecondDimensionWatcherReDive.Test/SyncFeedTests.cs`) but `dotnet test` was not executed in this environment because the `dotnet` SDK is not available here; please run `dotnet test SecondDimensionWatcherReDive.slnx` in CI or a local dev environment to validate behavior.
- Manual verification: local repository commands and source inspection were used to confirm the new logic replaces RSS-trusted size with the torrent-declared size and prevents AutoDownload submission on mismatch or invalid declarations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a91a9386148832c89054d1e6799f7f6)