### PR TITLE
test: add PostgreSQL Testcontainers integration, FUSE unit tests, SdwClient retry/refactor, and CI coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build & Release
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
   workflow_dispatch:
     inputs:
       release_version:
@@ -25,14 +27,20 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Run tests
-        run: dotnet test SecondDimensionWatcherReDive.slnx -c Release --logger "trx;LogFileName=test-results.trx"
+        run: >-
+          dotnet test SecondDimensionWatcherReDive.slnx -c Release
+          --logger "trx;LogFileName=test-results.trx"
+          --collect "XPlat Code Coverage"
+          -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results
-          path: '**/TestResults/*.trx'
+          path: |
+            **/TestResults/*.trx
+            **/TestResults/**/coverage.cobertura.xml
 
   build-frontend:
     needs: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   test:
@@ -43,6 +43,7 @@ jobs:
             **/TestResults/**/coverage.cobertura.xml
 
   build-frontend:
+    if: github.event_name != 'pull_request'
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -69,6 +70,7 @@ jobs:
           path: SecondDimensionWatcherReDive.Client/dist/
 
   build-linux-packages:
+    if: github.event_name != 'pull_request'
     needs: build-frontend
     runs-on: ubuntu-latest
     strategy:
@@ -145,6 +147,7 @@ jobs:
           path: dist/*
 
   build-windows-zip:
+    if: github.event_name != 'pull_request'
     needs: build-frontend
     runs-on: ubuntu-latest
     strategy:
@@ -198,6 +201,7 @@ jobs:
           path: sdw-redive_*.zip
 
   build-portable:
+    if: github.event_name != 'pull_request'
     needs: build-frontend
     runs-on: ubuntu-latest
     steps:
@@ -249,6 +253,7 @@ jobs:
           path: dist/*
 
   build-fuse:
+    if: github.event_name != 'pull_request'
     # NativeAOT cross-compile is not supported, so each architecture builds on a
     # native runner. ubuntu-24.04-arm is GA for public repos; private repos pay
     # for arm minutes — switch to a self-hosted arm runner if that becomes an
@@ -334,7 +339,10 @@ jobs:
           path: dist/*
 
   release:
+    if: github.event_name != 'pull_request'
     needs: [build-linux-packages, build-windows-zip, build-portable, build-fuse]
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/SecondDimensionWatcherReDive.FUSE.Test/FuseCoreTests.cs
+++ b/SecondDimensionWatcherReDive.FUSE.Test/FuseCoreTests.cs
@@ -1,0 +1,85 @@
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using SecondDimensionWatcherReDive.FUSE.Client;
+using SecondDimensionWatcherReDive.FUSE.Fs;
+using SecondDimensionWatcherReDive.FUSE.Native;
+
+namespace SecondDimensionWatcherReDive.FUSE.Test;
+
+[TestClass]
+public sealed class FuseCoreTests
+{
+    [TestMethod]
+    public void AttrCache_PrewarmsChildren_AndExpiresEntries()
+    {
+        var cache = new AttrCache(TimeSpan.FromMilliseconds(20));
+        var child = new VfsEntry("episode.mkv", false, 42, DateTimeOffset.UtcNow);
+        cache.PutList("/anime", [child]);
+
+        Assert.IsTrue(cache.TryGetStat("/anime/episode.mkv", out var cached));
+        Assert.AreEqual(child, cached);
+        Thread.Sleep(40);
+        Assert.IsFalse(cache.TryGetStat("/anime/episode.mkv", out _));
+    }
+
+    [TestMethod]
+    public void FileHandleTable_AllocatesUniqueHandles_AndReleasesThem()
+    {
+        var table = new FileHandleTable();
+        var first = table.Allocate("/one");
+        var second = table.Allocate("/two");
+
+        Assert.AreNotEqual(first, second);
+        Assert.IsTrue(table.TryGet(first, out var file));
+        Assert.AreEqual("/one", file.VirtualPath);
+        table.Release(first);
+        Assert.IsFalse(table.TryGet(first, out _));
+    }
+
+    [TestMethod]
+    public async Task SdwClient_ReadRetriesServerErrors_AndPreservesRange()
+    {
+        var calls = 0;
+        var handler = new StubHandler(request =>
+        {
+            calls++;
+            Assert.AreEqual("bytes=5-7", request.Headers.Range?.ToString());
+            return calls < 3
+                ? new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                : new HttpResponseMessage(HttpStatusCode.PartialContent)
+                {
+                    Content = new ByteArrayContent([10, 11, 12])
+                };
+        });
+        using var client = new SdwClient(new Uri("http://localhost"), "user", "token", "test",
+            NullLogger<SdwClient>.Instance, handler);
+        var buffer = new byte[3];
+
+        var read = await client.ReadAsync("/episode.mkv", 5, buffer, 0, 3, CancellationToken.None);
+
+        Assert.AreEqual(3, calls);
+        Assert.AreEqual(3, read);
+        CollectionAssert.AreEqual(new byte[] { 10, 11, 12 }, buffer);
+    }
+
+    [TestMethod]
+    public async Task SdwClient_ReadMapsHttpStatusesToErrno()
+    {
+        using var missing = CreateClient(HttpStatusCode.NotFound);
+        using var failed = CreateClient(HttpStatusCode.BadGateway);
+        var buffer = new byte[1];
+
+        Assert.AreEqual(-Errno.ENOENT, await missing.ReadAsync("/missing", 0, buffer, 0, 1, CancellationToken.None));
+        Assert.AreEqual(-Errno.EIO, await failed.ReadAsync("/failed", 0, buffer, 0, 1, CancellationToken.None));
+    }
+
+    private static SdwClient CreateClient(HttpStatusCode status) => new(new Uri("http://localhost"),
+        "user", "token", "test", NullLogger<SdwClient>.Instance,
+        new StubHandler(_ => new HttpResponseMessage(status)));
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> response) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+            CancellationToken cancellationToken) => Task.FromResult(response(request));
+    }
+}

--- a/SecondDimensionWatcherReDive.FUSE.Test/SecondDimensionWatcherReDive.FUSE.Test.csproj
+++ b/SecondDimensionWatcherReDive.FUSE.Test/SecondDimensionWatcherReDive.FUSE.Test.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <AssemblyName>SecondDimensionWatcherReDive.FUSE.Test</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SecondDimensionWatcherReDive.FUSE\SecondDimensionWatcherReDive.FUSE.csproj" />
+  </ItemGroup>
+</Project>

--- a/SecondDimensionWatcherReDive.FUSE/Client/SdwClient.cs
+++ b/SecondDimensionWatcherReDive.FUSE/Client/SdwClient.cs
@@ -15,14 +15,19 @@ internal sealed class SdwClient : IDisposable
     private bool _disposed;
 
     public SdwClient(Uri serverBaseUrl, string username, string password, string userAgent, ILogger<SdwClient> logger)
-    {
-        _logger = logger;
-        var handler = new SocketsHttpHandler
+        : this(serverBaseUrl, username, password, userAgent, logger, new SocketsHttpHandler
         {
             PooledConnectionLifetime = TimeSpan.FromMinutes(5),
             PooledConnectionIdleTimeout = TimeSpan.FromMinutes(2),
             AutomaticDecompression = DecompressionMethods.None,
-        };
+        })
+    {
+    }
+
+    internal SdwClient(Uri serverBaseUrl, string username, string password, string userAgent,
+        ILogger<SdwClient> logger, HttpMessageHandler handler)
+    {
+        _logger = logger;
         _http = new HttpClient(handler, disposeHandler: true)
         {
             BaseAddress = serverBaseUrl,
@@ -58,10 +63,9 @@ internal sealed class SdwClient : IDisposable
         CancellationToken cancellationToken)
     {
         var url = $"/api/vfs/read?path={EncodePath(virtualPath)}";
-        using var request = new HttpRequestMessage(HttpMethod.Get, url);
-        request.Headers.Range = new RangeHeaderValue(offset, offset + count - 1);
-
-        using var response = await _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        using var response = await SendWithRetryAsync(HttpMethod.Get, url, cancellationToken,
+            request => request.Headers.Range = new RangeHeaderValue(offset, offset + count - 1),
+            HttpCompletionOption.ResponseHeadersRead);
         if (response.StatusCode == HttpStatusCode.NotFound) return -Native.Errno.ENOENT;
         if (response.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable) return 0;
         if (response.StatusCode == HttpStatusCode.Unauthorized)
@@ -84,7 +88,9 @@ internal sealed class SdwClient : IDisposable
         return total;
     }
 
-    private async Task<HttpResponseMessage> SendWithRetryAsync(HttpMethod method, string url, CancellationToken cancellationToken)
+    private async Task<HttpResponseMessage> SendWithRetryAsync(HttpMethod method, string url,
+        CancellationToken cancellationToken, Action<HttpRequestMessage>? configureRequest = null,
+        HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
     {
         const int MaxAttempts = 3;
         Exception? last = null;
@@ -93,7 +99,8 @@ internal sealed class SdwClient : IDisposable
             try
             {
                 using var request = new HttpRequestMessage(method, url);
-                var response = await _http.SendAsync(request, cancellationToken);
+                configureRequest?.Invoke(request);
+                var response = await _http.SendAsync(request, completionOption, cancellationToken);
                 if ((int)response.StatusCode >= 500 && attempt < MaxAttempts)
                 {
                     response.Dispose();

--- a/SecondDimensionWatcherReDive.FUSE/Properties/AssemblyInfo.cs
+++ b/SecondDimensionWatcherReDive.FUSE/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SecondDimensionWatcherReDive.FUSE.Test")]

--- a/SecondDimensionWatcherReDive.IntegrationTest/PostgreSql/FileMappingRepositoryPostgreSqlTests.cs
+++ b/SecondDimensionWatcherReDive.IntegrationTest/PostgreSql/FileMappingRepositoryPostgreSqlTests.cs
@@ -1,9 +1,7 @@
 using Microsoft.EntityFrameworkCore;
-using SecondDimensionWatcherReDive.Repositories;
 using Testcontainers.PostgreSql;
-using DomainFileMapping = SecondDimensionWatcherReDive.Framework.DataRepository.FileMapping;
-using ApplicationContext = SecondDimensionWatcherReDive.Models.ApplicationContext;
-using AnimationInfoEntity = SecondDimensionWatcherReDive.Models.AnimationInfo;
+using SecondDimensionWatcherReDive.Framework.DataRepository;
+using SecondDimensionWatcherReDive.Repositories;
 
 namespace SecondDimensionWatcherReDive.IntegrationTest.PostgreSql;
 
@@ -20,17 +18,14 @@ public sealed class FileMappingRepositoryPostgreSqlTests
         .WithPassword("postgres")
         .Build();
 
-    private static DbContextOptions<ApplicationContext> _options = null!;
+    private static FileMappingRepositoryPostgreSqlTestFixture Fixture = null!;
 
     [ClassInitialize]
     public static async Task InitializeAsync(TestContext _)
     {
         await Database.StartAsync();
-        _options = new DbContextOptionsBuilder<ApplicationContext>()
-            .UseNpgsql(Database.GetConnectionString())
-            .Options;
-        await using var context = new ApplicationContext(_options);
-        await context.Database.MigrateAsync();
+        Fixture = new FileMappingRepositoryPostgreSqlTestFixture(Database.GetConnectionString());
+        await Fixture.InitializeAsync(CancellationToken.None);
     }
 
     [ClassCleanup]
@@ -39,25 +34,21 @@ public sealed class FileMappingRepositoryPostgreSqlTests
     [TestInitialize]
     public async Task ResetDatabaseAsync()
     {
-        await using var context = new ApplicationContext(_options);
-        await context.Database.ExecuteSqlRawAsync(
-            "TRUNCATE TABLE \"FileMappings\", \"AnimationInfo\" RESTART IDENTITY CASCADE");
+        await Fixture.ResetAsync(CancellationToken.None);
     }
 
     [TestMethod]
     public async Task PrefixQuery_EscapesLikeWildcards_AndRootQueryUsesPostgreSqlRawSql()
     {
-        var info = await SeedDownloadedAnimationAsync();
-        await using var context = new ApplicationContext(_options);
-        var repository = new FileMappingRepository(context, _options);
-        await repository.AddRangeAsync([
-            Mapping(info.Id, "/shows/100%_real/episode.mkv"),
-            Mapping(info.Id, "/shows/100xxreal/other.mkv")
+        var infoId = await Fixture.SeedDownloadedAnimationAsync(CancellationToken.None);
+        await Fixture.AddRangeAsync([
+            Mapping(infoId, "/shows/100%_real/episode.mkv"),
+            Mapping(infoId, "/shows/100xxreal/other.mkv")
         ], CancellationToken.None);
 
-        var matches = await repository.GetByVirtualPathPrefixAsync(
+        var matches = await Fixture.GetByVirtualPathPrefixAsync(
             "/shows/100%_real", CancellationToken.None);
-        var roots = await repository.GetRootEntriesAsync(CancellationToken.None);
+        var roots = await Fixture.GetRootEntriesAsync(CancellationToken.None);
 
         Assert.HasCount(1, matches);
         Assert.AreEqual("/shows/100%_real/episode.mkv", matches[0].VirtualPath);
@@ -69,18 +60,16 @@ public sealed class FileMappingRepositoryPostgreSqlTests
     [TestMethod]
     public async Task ConcurrentWriters_AreSerialized_AndFailedTransactionRollsBack()
     {
-        var firstInfo = await SeedDownloadedAnimationAsync();
-        var secondInfo = await SeedDownloadedAnimationAsync();
+        var firstInfoId = await Fixture.SeedDownloadedAnimationAsync(CancellationToken.None);
+        var secondInfoId = await Fixture.SeedDownloadedAnimationAsync(CancellationToken.None);
         const string CollidingPath = "/anime/shared.mkv";
 
-        static async Task<bool> WriteAsync(DbContextOptions<ApplicationContext> options,
-            DomainFileMapping mapping)
+        static async Task<bool> WriteAsync(FileMappingRepositoryPostgreSqlTestFixture fixture,
+            FileMapping mapping)
         {
-            await using var context = new ApplicationContext(options);
-            var repository = new FileMappingRepository(context, options);
             try
             {
-                await repository.AddRangeAsync([mapping], CancellationToken.None);
+                await fixture.AddRangeAsync([mapping], CancellationToken.None);
                 return true;
             }
             catch (DbUpdateException)
@@ -90,33 +79,15 @@ public sealed class FileMappingRepositoryPostgreSqlTests
         }
 
         var results = await Task.WhenAll(
-            WriteAsync(_options, Mapping(firstInfo.Id, CollidingPath)),
-            WriteAsync(_options, Mapping(secondInfo.Id, CollidingPath)));
+            WriteAsync(Fixture, Mapping(firstInfoId, CollidingPath)),
+            WriteAsync(Fixture, Mapping(secondInfoId, CollidingPath)));
 
         Assert.AreEqual(1, results.Count(result => result));
-        await using var verification = new ApplicationContext(_options);
-        Assert.AreEqual(1, await verification.FileMappings.CountAsync());
-        var versions = await verification.AnimationInfo.OrderBy(info => info.Id)
-            .Select(info => info.StateVersion).ToListAsync();
+        Assert.AreEqual(1, await Fixture.GetMappingCountAsync(CancellationToken.None));
+        var versions = await Fixture.GetAnimationInfoStateVersionsAsync(CancellationToken.None);
         CollectionAssert.AreEquivalent(new long[] { 0, 1 }, versions);
     }
 
-    private static async Task<AnimationInfoEntity> SeedDownloadedAnimationAsync()
-    {
-        await using var context = new ApplicationContext(_options);
-        var info = new AnimationInfoEntity
-        {
-            Id = Guid.NewGuid(),
-            Title = "integration test",
-            IsDownloadFinished = true,
-            FileStore = "local",
-            StorePath = "/store/" + Guid.NewGuid().ToString("N")
-        };
-        context.AnimationInfo.Add(info);
-        await context.SaveChangesAsync();
-        return info;
-    }
-
-    private static DomainFileMapping Mapping(Guid animationInfoId, string virtualPath) =>
+    private static FileMapping Mapping(Guid animationInfoId, string virtualPath) =>
         new(Guid.NewGuid(), animationInfoId, virtualPath, "/physical/" + Guid.NewGuid(), "local");
 }

--- a/SecondDimensionWatcherReDive.IntegrationTest/PostgreSql/FileMappingRepositoryPostgreSqlTests.cs
+++ b/SecondDimensionWatcherReDive.IntegrationTest/PostgreSql/FileMappingRepositoryPostgreSqlTests.cs
@@ -1,0 +1,122 @@
+using Microsoft.EntityFrameworkCore;
+using SecondDimensionWatcherReDive.Repositories;
+using Testcontainers.PostgreSql;
+using DomainFileMapping = SecondDimensionWatcherReDive.Framework.DataRepository.FileMapping;
+using ApplicationContext = SecondDimensionWatcherReDive.Models.ApplicationContext;
+using AnimationInfoEntity = SecondDimensionWatcherReDive.Models.AnimationInfo;
+
+namespace SecondDimensionWatcherReDive.IntegrationTest.PostgreSql;
+
+/// <summary>
+/// Exercises the PostgreSQL-only repository surface against a migrated, disposable database.
+/// Testcontainers owns container cleanup even when a test fails or the run is cancelled.
+/// </summary>
+[TestClass]
+public sealed class FileMappingRepositoryPostgreSqlTests
+{
+    private static readonly PostgreSqlContainer Database = new PostgreSqlBuilder("postgres:17-alpine")
+        .WithDatabase("sdw_tests")
+        .WithUsername("postgres")
+        .WithPassword("postgres")
+        .Build();
+
+    private static DbContextOptions<ApplicationContext> _options = null!;
+
+    [ClassInitialize]
+    public static async Task InitializeAsync(TestContext _)
+    {
+        await Database.StartAsync();
+        _options = new DbContextOptionsBuilder<ApplicationContext>()
+            .UseNpgsql(Database.GetConnectionString())
+            .Options;
+        await using var context = new ApplicationContext(_options);
+        await context.Database.MigrateAsync();
+    }
+
+    [ClassCleanup]
+    public static async Task CleanupAsync() => await Database.DisposeAsync();
+
+    [TestInitialize]
+    public async Task ResetDatabaseAsync()
+    {
+        await using var context = new ApplicationContext(_options);
+        await context.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE \"FileMappings\", \"AnimationInfo\" RESTART IDENTITY CASCADE");
+    }
+
+    [TestMethod]
+    public async Task PrefixQuery_EscapesLikeWildcards_AndRootQueryUsesPostgreSqlRawSql()
+    {
+        var info = await SeedDownloadedAnimationAsync();
+        await using var context = new ApplicationContext(_options);
+        var repository = new FileMappingRepository(context, _options);
+        await repository.AddRangeAsync([
+            Mapping(info.Id, "/shows/100%_real/episode.mkv"),
+            Mapping(info.Id, "/shows/100xxreal/other.mkv")
+        ], CancellationToken.None);
+
+        var matches = await repository.GetByVirtualPathPrefixAsync(
+            "/shows/100%_real", CancellationToken.None);
+        var roots = await repository.GetRootEntriesAsync(CancellationToken.None);
+
+        Assert.HasCount(1, matches);
+        Assert.AreEqual("/shows/100%_real/episode.mkv", matches[0].VirtualPath);
+        Assert.HasCount(1, roots);
+        Assert.AreEqual("shows", roots[0].Name);
+        Assert.IsTrue(roots[0].IsDirectory);
+    }
+
+    [TestMethod]
+    public async Task ConcurrentWriters_AreSerialized_AndFailedTransactionRollsBack()
+    {
+        var firstInfo = await SeedDownloadedAnimationAsync();
+        var secondInfo = await SeedDownloadedAnimationAsync();
+        const string CollidingPath = "/anime/shared.mkv";
+
+        static async Task<bool> WriteAsync(DbContextOptions<ApplicationContext> options,
+            DomainFileMapping mapping)
+        {
+            await using var context = new ApplicationContext(options);
+            var repository = new FileMappingRepository(context, options);
+            try
+            {
+                await repository.AddRangeAsync([mapping], CancellationToken.None);
+                return true;
+            }
+            catch (DbUpdateException)
+            {
+                return false;
+            }
+        }
+
+        var results = await Task.WhenAll(
+            WriteAsync(_options, Mapping(firstInfo.Id, CollidingPath)),
+            WriteAsync(_options, Mapping(secondInfo.Id, CollidingPath)));
+
+        Assert.AreEqual(1, results.Count(result => result));
+        await using var verification = new ApplicationContext(_options);
+        Assert.AreEqual(1, await verification.FileMappings.CountAsync());
+        var versions = await verification.AnimationInfo.OrderBy(info => info.Id)
+            .Select(info => info.StateVersion).ToListAsync();
+        CollectionAssert.AreEquivalent(new long[] { 0, 1 }, versions);
+    }
+
+    private static async Task<AnimationInfoEntity> SeedDownloadedAnimationAsync()
+    {
+        await using var context = new ApplicationContext(_options);
+        var info = new AnimationInfoEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = "integration test",
+            IsDownloadFinished = true,
+            FileStore = "local",
+            StorePath = "/store/" + Guid.NewGuid().ToString("N")
+        };
+        context.AnimationInfo.Add(info);
+        await context.SaveChangesAsync();
+        return info;
+    }
+
+    private static DomainFileMapping Mapping(Guid animationInfoId, string virtualPath) =>
+        new(Guid.NewGuid(), animationInfoId, virtualPath, "/physical/" + Guid.NewGuid(), "local");
+}

--- a/SecondDimensionWatcherReDive.IntegrationTest/SecondDimensionWatcherReDive.IntegrationTest.csproj
+++ b/SecondDimensionWatcherReDive.IntegrationTest/SecondDimensionWatcherReDive.IntegrationTest.csproj
@@ -17,6 +17,11 @@
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
         <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Testcontainers.PostgreSql" Version="4.14.0" />
         <PackageReference Include="WebDav.Client" Version="2.9.0" />
     </ItemGroup>
 

--- a/SecondDimensionWatcherReDive.slnx
+++ b/SecondDimensionWatcherReDive.slnx
@@ -4,6 +4,7 @@
   <Project Path="SecondDimensionWatcherReDive.IntegrationTest/SecondDimensionWatcherReDive.IntegrationTest.csproj" />
   <Project Path="SecondDimensionWatcherReDive/SecondDimensionWatcherReDive.csproj" />
   <Project Path="SecondDimensionWatcherReDive.FUSE/SecondDimensionWatcherReDive.FUSE.csproj" />
+  <Project Path="SecondDimensionWatcherReDive.FUSE.Test/SecondDimensionWatcherReDive.FUSE.Test.csproj" />
   <Folder Name="/Plugins/">
     <Project Path="Plugins/SecondDimensionWatcherReDive.AI/SecondDimensionWatcherReDive.AI.csproj" />
     <Project Path="Plugins/SecondDimensionWatcherReDive.Chat/SecondDimensionWatcherReDive.Chat.csproj" />

--- a/SecondDimensionWatcherReDive/Repositories/FileMappingRepositoryPostgreSqlTestFixture.cs
+++ b/SecondDimensionWatcherReDive/Repositories/FileMappingRepositoryPostgreSqlTestFixture.cs
@@ -1,0 +1,86 @@
+using Microsoft.EntityFrameworkCore;
+using SecondDimensionWatcherReDive.Framework.DataRepository;
+
+namespace SecondDimensionWatcherReDive.Repositories;
+
+/// <summary>
+/// Owns PostgreSQL setup and inspection for repository integration tests without
+/// exposing the EF context outside the repository implementation boundary.
+/// </summary>
+internal sealed class FileMappingRepositoryPostgreSqlTestFixture(string connectionString)
+{
+    private readonly DbContextOptions<Models.ApplicationContext> _contextOptions =
+        new DbContextOptionsBuilder<Models.ApplicationContext>()
+            .UseNpgsql(connectionString)
+            .Options;
+
+    public async Task InitializeAsync(CancellationToken cancellationToken)
+    {
+        await using var context = new Models.ApplicationContext(_contextOptions);
+        await context.Database.MigrateAsync(cancellationToken);
+    }
+
+    public async Task ResetAsync(CancellationToken cancellationToken)
+    {
+        await using var context = new Models.ApplicationContext(_contextOptions);
+        await context.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE \"FileMappings\", \"AnimationInfo\" RESTART IDENTITY CASCADE",
+            cancellationToken);
+    }
+
+    public async Task<Guid> SeedDownloadedAnimationAsync(CancellationToken cancellationToken)
+    {
+        await using var context = new Models.ApplicationContext(_contextOptions);
+        var info = new Models.AnimationInfo
+        {
+            Id = Guid.NewGuid(),
+            Title = "integration test",
+            IsDownloadFinished = true,
+            FileStore = "local",
+            StorePath = "/store/" + Guid.NewGuid().ToString("N")
+        };
+        context.AnimationInfo.Add(info);
+        await context.SaveChangesAsync(cancellationToken);
+        return info.Id;
+    }
+
+    public async Task AddRangeAsync(
+        IReadOnlyList<FileMapping> mappings,
+        CancellationToken cancellationToken)
+    {
+        await using var context = new Models.ApplicationContext(_contextOptions);
+        var repository = new FileMappingRepository(context, _contextOptions);
+        await repository.AddRangeAsync(mappings, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<FileMapping>> GetByVirtualPathPrefixAsync(
+        string virtualPathPrefix,
+        CancellationToken cancellationToken)
+    {
+        await using var context = new Models.ApplicationContext(_contextOptions);
+        var repository = new FileMappingRepository(context, _contextOptions);
+        return await repository.GetByVirtualPathPrefixAsync(virtualPathPrefix, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<RootEntry>> GetRootEntriesAsync(CancellationToken cancellationToken)
+    {
+        await using var context = new Models.ApplicationContext(_contextOptions);
+        var repository = new FileMappingRepository(context, _contextOptions);
+        return await repository.GetRootEntriesAsync(cancellationToken);
+    }
+
+    public async Task<int> GetMappingCountAsync(CancellationToken cancellationToken)
+    {
+        await using var context = new Models.ApplicationContext(_contextOptions);
+        return await context.FileMappings.CountAsync(cancellationToken);
+    }
+
+    public async Task<long[]> GetAnimationInfoStateVersionsAsync(CancellationToken cancellationToken)
+    {
+        await using var context = new Models.ApplicationContext(_contextOptions);
+        return await context.AnimationInfo
+            .OrderBy(info => info.Id)
+            .Select(info => info.StateVersion)
+            .ToArrayAsync(cancellationToken);
+    }
+}

--- a/SecondDimensionWatcherReDive/SecondDimensionWatcherReDive.csproj
+++ b/SecondDimensionWatcherReDive/SecondDimensionWatcherReDive.csproj
@@ -35,7 +35,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="SecondDimensionWatcherReDive.Test" />
+      <InternalsVisibleTo Include="SecondDimensionWatcherReDive.Test" />
+      <InternalsVisibleTo Include="SecondDimensionWatcherReDive.IntegrationTest" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Motivation

- 增强对生产边界的自动化验证，补齐对真实 PostgreSQL 特性（advisory lock、raw SQL、LIKE 转义、并发写入、事务回滚）和 FUSE 客户端核心行为的测试覆盖。  
- 使 FUSE 的 HTTP 读取复用已有的重试策略同时保证 `Range` header 在重试中被保留，便于对真实网络误差进行稳健性验证。  
- 在 CI 中为 Pull Request 启用测试运行并产出 TRX + Cobertura 覆盖率工件以便持续回归监控。

### Description

- 新增基于 Testcontainers 的 PostgreSQL 集成测试并执行 EF Core 迁移，新增文件 `SecondDimensionWatcherReDive.IntegrationTest/PostgreSql/FileMappingRepositoryPostgreSqlTests.cs`，并在测试项目中添加 `Testcontainers.PostgreSql` 与 `coverlet.collector` 依赖。  
- 新增 FUSE 单元测试项目 `SecondDimensionWatcherReDive.FUSE.Test` 及测试 `FuseCoreTests.cs`，覆盖 `AttrCache`、`FileHandleTable` 行为以及 `SdwClient` 的 range 读取重试与 errno 映射用例。  
- 重构 `SdwClient`：增加可注入的 `HttpMessageHandler` 构造器入口、将 `SendWithRetryAsync` 扩展为可接受 `configureRequest` 回调和 `HttpCompletionOption` 参数，以便在重试时重新附加 `Range` header 并保留现有指数退避策略（修改文件 `SecondDimensionWatcherReDive.FUSE/Client/SdwClient.cs`）。  
- 为测试访问添加 `InternalsVisibleTo`（`SecondDimensionWatcherReDive.FUSE/Properties/AssemblyInfo.cs`），并将 FUSE tests 加入解决方案文件和新 csproj。  
- 更新 CI workflow（`.github/workflows/build.yml`）以在 `pull_request` 触发下运行，并在 `dotnet test` 中收集 Cobertura 格式覆盖率，上传 TRX 与 coverage 工件供分析。

### Testing

- 已在本地运行 `yarn test`，前端单元套件全部通过并打印通过结果。  
- 已在本地运行 `yarn build`，前端构建成功并生成 `dist/`（构建产物已生成）。  
- 执行 `git diff --check` 与基本仓库状态检查通过且工作区在提交后干净。  
- 未能在当前环境本地运行 `.NET` 测试（`dotnet` 未安装），因此 PostgreSQL Testcontainers 与 .NET 单元/集成测试需要在 CI（已更新）或带有 .NET 10 的本地环境中运行；CI 将执行完整解决方案测试并上传 TRX + Cobertura 结果。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a919fec5e24832c873b732e6a8b4ef4)