### PR TITLE
ci: build container images on native runners

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -3,6 +3,11 @@ name: Container Build & Publish
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - ".github/workflows/container.yml"
+      - "Containerfile"
   workflow_dispatch:
     inputs:
       release_version:
@@ -12,38 +17,133 @@ on:
 
 permissions:
   contents: read
-  packages: write
+
+concurrency:
+  group: container-${{ github.ref }}-${{ github.event.inputs.release_version || 'prerelease' }}
+  cancel-in-progress: true
 
 jobs:
-  build-and-push:
+  prepare:
     runs-on: ubuntu-latest
+    outputs:
+      registry_image: ${{ steps.image.outputs.registry_image }}
+      tag1: ${{ steps.image.outputs.tag1 }}
+      tag2: ${{ steps.image.outputs.tag2 }}
     steps:
       - uses: actions/checkout@v7
 
       - name: Compute image name and version
+        id: image
         run: |
           REGISTRY="ghcr.io"
           RELEASE_VERSION="${{ github.event.inputs.release_version }}"
           IMAGE_NAME=$(echo "${{ github.repository_owner }}/sdw-redive" | tr '[:upper:]' '[:lower:]')
+          REGISTRY_IMAGE="${REGISTRY}/${IMAGE_NAME}"
 
           if [ -n "$RELEASE_VERSION" ]; then
             VERSION="$RELEASE_VERSION"
-            TAG1="${REGISTRY}/${IMAGE_NAME}:${VERSION}"
-            TAG2="${REGISTRY}/${IMAGE_NAME}:latest"
+            TAG1="${REGISTRY_IMAGE}:${VERSION}"
+            TAG2="${REGISTRY_IMAGE}:latest"
           else
-            BASE_VERSION=$(cat VERSION | tr -d '[:space:]')
+            BASE_VERSION=$(tr -d '[:space:]' < VERSION)
             VERSION="${BASE_VERSION}.${{ github.run_number }}"
-            TAG1="${REGISTRY}/${IMAGE_NAME}:pre-${VERSION}"
-            TAG2="${REGISTRY}/${IMAGE_NAME}:prerelease-latest"
+            TAG1="${REGISTRY_IMAGE}:pre-${VERSION}"
+            TAG2="${REGISTRY_IMAGE}:prerelease-latest"
           fi
 
-          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
-          echo "IMAGE_NAME=${IMAGE_NAME}" >> "$GITHUB_ENV"
-          echo "TAG1=${TAG1}" >> "$GITHUB_ENV"
-          echo "TAG2=${TAG2}" >> "$GITHUB_ENV"
+          echo "registry_image=${REGISTRY_IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "tag1=${TAG1}" >> "$GITHUB_OUTPUT"
+          echo "tag2=${TAG2}" >> "$GITHUB_OUTPUT"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+  build:
+    needs: prepare
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build container
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Containerfile
+          platforms: ${{ matrix.platform }}
+          push: false
+          cache-from: type=gha,scope=container-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=container-${{ matrix.arch }}
+
+      - name: Build and push by digest
+        if: github.event_name != 'pull_request'
+        id: publish
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Containerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ needs.prepare.outputs.registry_image }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=container-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=container-${{ matrix.arch }}
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.publish.outputs.digest }}
+        run: |
+          digest="${DIGEST#sha256:}"
+          if [[ ! "$digest" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "Unexpected image digest: $DIGEST" >&2
+            exit 1
+          fi
+          mkdir -p "$RUNNER_TEMP/container-digests"
+          touch "$RUNNER_TEMP/container-digests/$digest"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: container-digest-${{ matrix.arch }}
+          path: ${{ runner.temp }}/container-digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-manifest:
+    if: github.event_name != 'pull_request'
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v8
+        with:
+          pattern: container-digest-*
+          path: ${{ runner.temp }}/container-digests
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -55,15 +155,41 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Containerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ env.TAG1 }}
-            ${{ env.TAG2 }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create and verify multi-platform manifest
+        env:
+          REGISTRY_IMAGE: ${{ needs.prepare.outputs.registry_image }}
+          TAG1: ${{ needs.prepare.outputs.tag1 }}
+          TAG2: ${{ needs.prepare.outputs.tag2 }}
+        run: |
+          mapfile -t digests < <(
+            find "$RUNNER_TEMP/container-digests" -maxdepth 1 -type f -printf '%f\n' | sort
+          )
+          if [ "${#digests[@]}" -ne 2 ]; then
+            echo "Expected two platform digests, found ${#digests[@]}" >&2
+            exit 1
+          fi
+
+          images=()
+          for digest in "${digests[@]}"; do
+            if [[ ! "$digest" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "Unexpected image digest: $digest" >&2
+              exit 1
+            fi
+            images+=("${REGISTRY_IMAGE}@sha256:${digest}")
+          done
+
+          docker buildx imagetools create \
+            --tag "$TAG1" \
+            --tag "$TAG2" \
+            "${images[@]}"
+
+          manifest=$(docker buildx imagetools inspect "$TAG1" --raw)
+          for architecture in amd64 arm64; do
+            if ! jq -e --arg architecture "$architecture" \
+              'any(.manifests[]?; .platform.os == "linux" and .platform.architecture == $architecture)' \
+              <<< "$manifest" >/dev/null; then
+              echo "Published manifest is missing linux/$architecture" >&2
+              exit 1
+            fi
+          done
+          docker buildx imagetools inspect "$TAG1"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -225,6 +225,14 @@ jobs:
             exit 1
           fi
 
+          invalid_auxiliary=$(jq -c \
+            '[.manifests[]? | select((.platform.os // "unknown") == "unknown" and (.platform.architecture // "unknown") == "unknown") | select(.annotations["vnd.docker.reference.type"] != "attestation-manifest")]' \
+            <<< "$manifest")
+          if [ "$invalid_auxiliary" != '[]' ]; then
+            echo "Manifest contains unexpected auxiliary descriptors: $invalid_auxiliary" >&2
+            exit 1
+          fi
+
           tag1_digest=$(docker buildx imagetools inspect "$TAG1" --format '{{json .Manifest}}' | jq -er '.digest')
           if [ "$tag1_digest" != "$manifest_digest" ]; then
             echo "$TAG1 points to $tag1_digest instead of $manifest_digest" >&2

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           EVENT_NAME: ${{ github.event_name }}
-          REF_NAME: ${{ github.ref_name }}
+          REF: ${{ github.ref }}
           RELEASE_VERSION: ${{ github.event.inputs.release_version }}
         run: |
           REGISTRY="ghcr.io"
@@ -49,7 +49,7 @@ jobs:
             echo "VERSION must use the x.y.z format" >&2
             exit 1
           fi
-          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$REF_NAME" != "$DEFAULT_BRANCH" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$REF" != "refs/heads/$DEFAULT_BRANCH" ]; then
             echo "Manual publication must run from $DEFAULT_BRANCH" >&2
             exit 1
           fi
@@ -277,7 +277,7 @@ jobs:
       packages: write
     concurrency:
       group: container-moving-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_version != '' && 'stable' || 'prerelease' }}
-      cancel-in-progress: false
+      queue: max
     steps:
       - uses: actions/checkout@v7
         with:
@@ -301,50 +301,31 @@ jobs:
           SOURCE_SHA: ${{ github.sha }}
           TAG2: ${{ needs.prepare.outputs.tag2 }}
         run: |
+          if [[ ! "$MANIFEST_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Unexpected manifest digest: $MANIFEST_DIGEST" >&2
+            exit 1
+          fi
+
           if [ -n "$RELEASE_VERSION" ]; then
             current_version=$(tr -d '[:space:]' < VERSION)
             if [[ ! "$current_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "Current VERSION must use the x.y.z format" >&2
               exit 1
             fi
-
-            version_tag="${REGISTRY_IMAGE}:${current_version}"
-            manifest=$(docker buildx imagetools inspect "$version_tag" --raw)
-
-            platforms=$(jq -c \
-              '[.manifests[]? | select((.platform.os // "unknown") != "unknown" or (.platform.architecture // "unknown") != "unknown") | "\(.platform.os)/\(.platform.architecture)"] | sort' \
-              <<< "$manifest")
-            if [ "$platforms" != '["linux/amd64","linux/arm64"]' ]; then
-              echo "Refusing to promote $version_tag with platforms $platforms" >&2
-              exit 1
+            if [ "$current_version" != "$RELEASE_VERSION" ]; then
+              echo "::notice::Not updating $TAG2 because current VERSION is $current_version, not $RELEASE_VERSION"
+              exit 0
             fi
-
-            invalid_auxiliary=$(jq -c \
-              '[.manifests[]? | select((.platform.os // "unknown") == "unknown" and (.platform.architecture // "unknown") == "unknown") | select(.annotations["vnd.docker.reference.type"] != "attestation-manifest")]' \
-              <<< "$manifest")
-            if [ "$invalid_auxiliary" != '[]' ]; then
-              echo "Refusing to promote $version_tag with unexpected auxiliary descriptors" >&2
-              exit 1
-            fi
-
-            target_digest="sha256:$(printf '%s' "$manifest" | sha256sum | cut -d ' ' -f1)"
           else
-            if [[ ! "$MANIFEST_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-              echo "Unexpected manifest digest: $MANIFEST_DIGEST" >&2
-              exit 1
-            fi
-
             current_sha=$(git rev-parse HEAD)
             if [ "$current_sha" != "$SOURCE_SHA" ]; then
               echo "::notice::Not updating $TAG2 because the default branch moved from $SOURCE_SHA to $current_sha"
               exit 0
             fi
-
-            target_digest="$MANIFEST_DIGEST"
-            manifest=$(docker buildx imagetools inspect "${REGISTRY_IMAGE}@${target_digest}" --raw)
           fi
 
-          docker buildx imagetools create --tag "$TAG2" "${REGISTRY_IMAGE}@${target_digest}"
+          manifest=$(docker buildx imagetools inspect "${REGISTRY_IMAGE}@${MANIFEST_DIGEST}" --raw)
+          docker buildx imagetools create --tag "$TAG2" "${REGISTRY_IMAGE}@${MANIFEST_DIGEST}"
           tag2_manifest=$(docker buildx imagetools inspect "$TAG2" --raw)
           if [ "$tag2_manifest" != "$manifest" ]; then
             echo "$TAG2 does not resolve to the validated manifest" >&2

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -297,22 +297,54 @@ jobs:
         env:
           MANIFEST_DIGEST: ${{ needs.publish-version.outputs.manifest_digest }}
           REGISTRY_IMAGE: ${{ needs.prepare.outputs.registry_image }}
+          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
           SOURCE_SHA: ${{ github.sha }}
           TAG2: ${{ needs.prepare.outputs.tag2 }}
         run: |
-          if [[ ! "$MANIFEST_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "Unexpected manifest digest: $MANIFEST_DIGEST" >&2
-            exit 1
+          if [ -n "$RELEASE_VERSION" ]; then
+            current_version=$(tr -d '[:space:]' < VERSION)
+            if [[ ! "$current_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Current VERSION must use the x.y.z format" >&2
+              exit 1
+            fi
+
+            version_tag="${REGISTRY_IMAGE}:${current_version}"
+            manifest=$(docker buildx imagetools inspect "$version_tag" --raw)
+
+            platforms=$(jq -c \
+              '[.manifests[]? | select((.platform.os // "unknown") != "unknown" or (.platform.architecture // "unknown") != "unknown") | "\(.platform.os)/\(.platform.architecture)"] | sort' \
+              <<< "$manifest")
+            if [ "$platforms" != '["linux/amd64","linux/arm64"]' ]; then
+              echo "Refusing to promote $version_tag with platforms $platforms" >&2
+              exit 1
+            fi
+
+            invalid_auxiliary=$(jq -c \
+              '[.manifests[]? | select((.platform.os // "unknown") == "unknown" and (.platform.architecture // "unknown") == "unknown") | select(.annotations["vnd.docker.reference.type"] != "attestation-manifest")]' \
+              <<< "$manifest")
+            if [ "$invalid_auxiliary" != '[]' ]; then
+              echo "Refusing to promote $version_tag with unexpected auxiliary descriptors" >&2
+              exit 1
+            fi
+
+            target_digest="sha256:$(printf '%s' "$manifest" | sha256sum | cut -d ' ' -f1)"
+          else
+            if [[ ! "$MANIFEST_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "Unexpected manifest digest: $MANIFEST_DIGEST" >&2
+              exit 1
+            fi
+
+            current_sha=$(git rev-parse HEAD)
+            if [ "$current_sha" != "$SOURCE_SHA" ]; then
+              echo "::notice::Not updating $TAG2 because the default branch moved from $SOURCE_SHA to $current_sha"
+              exit 0
+            fi
+
+            target_digest="$MANIFEST_DIGEST"
+            manifest=$(docker buildx imagetools inspect "${REGISTRY_IMAGE}@${target_digest}" --raw)
           fi
 
-          current_sha=$(git rev-parse HEAD)
-          if [ "$current_sha" != "$SOURCE_SHA" ]; then
-            echo "::notice::Not updating $TAG2 because the default branch moved from $SOURCE_SHA to $current_sha"
-            exit 0
-          fi
-
-          manifest=$(docker buildx imagetools inspect "${REGISTRY_IMAGE}@${MANIFEST_DIGEST}" --raw)
-          docker buildx imagetools create --tag "$TAG2" "${REGISTRY_IMAGE}@${MANIFEST_DIGEST}"
+          docker buildx imagetools create --tag "$TAG2" "${REGISTRY_IMAGE}@${target_digest}"
           tag2_manifest=$(docker buildx imagetools inspect "$TAG2" --raw)
           if [ "$tag2_manifest" != "$manifest" ]; then
             echo "$TAG2 does not resolve to the validated manifest" >&2

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -233,16 +233,16 @@ jobs:
             exit 1
           fi
 
-          tag1_digest=$(docker buildx imagetools inspect "$TAG1" --format '{{json .Manifest}}' | jq -er '.digest')
-          if [ "$tag1_digest" != "$manifest_digest" ]; then
-            echo "$TAG1 points to $tag1_digest instead of $manifest_digest" >&2
+          tag1_manifest=$(docker buildx imagetools inspect "$TAG1" --raw)
+          if [ "$tag1_manifest" != "$manifest" ]; then
+            echo "$TAG1 does not resolve to the validated manifest" >&2
             exit 1
           fi
 
           docker buildx imagetools create --tag "$TAG2" "${REGISTRY_IMAGE}@${manifest_digest}"
-          tag2_digest=$(docker buildx imagetools inspect "$TAG2" --format '{{json .Manifest}}' | jq -er '.digest')
-          if [ "$tag2_digest" != "$manifest_digest" ]; then
-            echo "$TAG2 points to $tag2_digest instead of $manifest_digest" >&2
+          tag2_manifest=$(docker buildx imagetools inspect "$TAG2" --raw)
+          if [ "$tag2_manifest" != "$manifest" ]; then
+            echo "$TAG2 does not resolve to the validated manifest" >&2
             exit 1
           fi
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -19,8 +19,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: container-${{ github.ref }}-${{ github.event.inputs.release_version || 'prerelease' }}
-  cancel-in-progress: true
+  group: container-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_version != '' && 'stable' || 'prerelease') }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   prepare:
@@ -34,18 +34,27 @@ jobs:
 
       - name: Compute image name and version
         id: image
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.release_version }}
         run: |
           REGISTRY="ghcr.io"
-          RELEASE_VERSION="${{ github.event.inputs.release_version }}"
           IMAGE_NAME=$(echo "${{ github.repository_owner }}/sdw-redive" | tr '[:upper:]' '[:lower:]')
           REGISTRY_IMAGE="${REGISTRY}/${IMAGE_NAME}"
 
           if [ -n "$RELEASE_VERSION" ]; then
+            if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Release version must use the x.y.z format" >&2
+              exit 1
+            fi
             VERSION="$RELEASE_VERSION"
             TAG1="${REGISTRY_IMAGE}:${VERSION}"
             TAG2="${REGISTRY_IMAGE}:latest"
           else
             BASE_VERSION=$(tr -d '[:space:]' < VERSION)
+            if [[ ! "$BASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "VERSION must use the x.y.z format" >&2
+              exit 1
+            fi
             VERSION="${BASE_VERSION}.${{ github.run_number }}"
             TAG1="${REGISTRY_IMAGE}:pre-${VERSION}"
             TAG2="${REGISTRY_IMAGE}:prerelease-latest"
@@ -55,7 +64,40 @@ jobs:
           echo "tag1=${TAG1}" >> "$GITHUB_OUTPUT"
           echo "tag2=${TAG2}" >> "$GITHUB_OUTPUT"
 
+  validate:
+    if: github.event_name == 'pull_request'
+    needs: prepare
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build container
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Containerfile
+          platforms: ${{ matrix.platform }}
+          push: false
+          cache-from: type=gha,scope=container-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=container-${{ matrix.arch }},ignore-error=true
+
   build:
+    if: github.event_name != 'pull_request'
     needs: prepare
     permissions:
       contents: read
@@ -78,26 +120,13 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build container
-        if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Containerfile
-          platforms: ${{ matrix.platform }}
-          push: false
-          cache-from: type=gha,scope=container-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=container-${{ matrix.arch }}
-
       - name: Build and push by digest
-        if: github.event_name != 'pull_request'
         id: publish
         uses: docker/build-push-action@v7
         with:
@@ -106,10 +135,9 @@ jobs:
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ needs.prepare.outputs.registry_image }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=container-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=container-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=container-${{ matrix.arch }},ignore-error=true
 
       - name: Export digest
-        if: github.event_name != 'pull_request'
         env:
           DIGEST: ${{ steps.publish.outputs.digest }}
         run: |
@@ -122,7 +150,6 @@ jobs:
           touch "$RUNNER_TEMP/container-digests/$digest"
 
       - name: Upload digest
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: container-digest-${{ matrix.arch }}
@@ -180,16 +207,35 @@ jobs:
 
           docker buildx imagetools create \
             --tag "$TAG1" \
-            --tag "$TAG2" \
+            --metadata-file "$RUNNER_TEMP/manifest-metadata.json" \
             "${images[@]}"
 
-          manifest=$(docker buildx imagetools inspect "$TAG1" --raw)
-          for architecture in amd64 arm64; do
-            if ! jq -e --arg architecture "$architecture" \
-              'any(.manifests[]?; .platform.os == "linux" and .platform.architecture == $architecture)' \
-              <<< "$manifest" >/dev/null; then
-              echo "Published manifest is missing linux/$architecture" >&2
-              exit 1
-            fi
-          done
-          docker buildx imagetools inspect "$TAG1"
+          manifest_digest=$(jq -er '."containerimage.descriptor".digest' "$RUNNER_TEMP/manifest-metadata.json")
+          if [[ ! "$manifest_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Unexpected manifest digest: $manifest_digest" >&2
+            exit 1
+          fi
+
+          manifest=$(docker buildx imagetools inspect "${REGISTRY_IMAGE}@${manifest_digest}" --raw)
+          platforms=$(jq -c \
+            '[.manifests[]? | select((.platform.os // "unknown") != "unknown" or (.platform.architecture // "unknown") != "unknown") | "\(.platform.os)/\(.platform.architecture)"] | sort' \
+            <<< "$manifest")
+          if [ "$platforms" != '["linux/amd64","linux/arm64"]' ]; then
+            echo "Expected exactly linux/amd64 and linux/arm64, found $platforms" >&2
+            exit 1
+          fi
+
+          tag1_digest=$(docker buildx imagetools inspect "$TAG1" --format '{{json .Manifest}}' | jq -er '.digest')
+          if [ "$tag1_digest" != "$manifest_digest" ]; then
+            echo "$TAG1 points to $tag1_digest instead of $manifest_digest" >&2
+            exit 1
+          fi
+
+          docker buildx imagetools create --tag "$TAG2" "${REGISTRY_IMAGE}@${manifest_digest}"
+          tag2_digest=$(docker buildx imagetools inspect "$TAG2" --format '{{json .Manifest}}' | jq -er '.digest')
+          if [ "$tag2_digest" != "$manifest_digest" ]; then
+            echo "$TAG2 points to $tag2_digest instead of $manifest_digest" >&2
+            exit 1
+          fi
+
+          docker buildx imagetools inspect "${REGISTRY_IMAGE}@${manifest_digest}"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -167,6 +167,7 @@ jobs:
           name: container-digest-${{ matrix.arch }}
           path: ${{ runner.temp }}/container-digests/*
           if-no-files-found: error
+          overwrite: true
           retention-days: 1
 
   publish-version:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: container-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_version != '' && 'stable' || 'prerelease') }}
+  group: container-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || (github.event_name == 'workflow_dispatch' && github.event.inputs.release_version != '' && format('stable-{0}', github.event.inputs.release_version) || 'prerelease') }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -35,26 +35,38 @@ jobs:
       - name: Compute image name and version
         id: image
         env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
           RELEASE_VERSION: ${{ github.event.inputs.release_version }}
         run: |
           REGISTRY="ghcr.io"
           IMAGE_NAME=$(echo "${{ github.repository_owner }}/sdw-redive" | tr '[:upper:]' '[:lower:]')
           REGISTRY_IMAGE="${REGISTRY}/${IMAGE_NAME}"
+          BASE_VERSION=$(tr -d '[:space:]' < VERSION)
+
+          if [[ ! "$BASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "VERSION must use the x.y.z format" >&2
+            exit 1
+          fi
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$REF_NAME" != "$DEFAULT_BRANCH" ]; then
+            echo "Manual publication must run from $DEFAULT_BRANCH" >&2
+            exit 1
+          fi
 
           if [ -n "$RELEASE_VERSION" ]; then
             if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "Release version must use the x.y.z format" >&2
               exit 1
             fi
+            if [ "$RELEASE_VERSION" != "$BASE_VERSION" ]; then
+              echo "Release version $RELEASE_VERSION does not match VERSION ($BASE_VERSION)" >&2
+              exit 1
+            fi
             VERSION="$RELEASE_VERSION"
             TAG1="${REGISTRY_IMAGE}:${VERSION}"
             TAG2="${REGISTRY_IMAGE}:latest"
           else
-            BASE_VERSION=$(tr -d '[:space:]' < VERSION)
-            if [[ ! "$BASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "VERSION must use the x.y.z format" >&2
-              exit 1
-            fi
             VERSION="${BASE_VERSION}.${{ github.run_number }}"
             TAG1="${REGISTRY_IMAGE}:pre-${VERSION}"
             TAG2="${REGISTRY_IMAGE}:prerelease-latest"
@@ -157,13 +169,15 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  publish-manifest:
+  publish-version:
     if: github.event_name != 'pull_request'
     needs: [prepare, build]
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      manifest_digest: ${{ steps.manifest.outputs.manifest_digest }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@v8
@@ -183,10 +197,10 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create and verify multi-platform manifest
+        id: manifest
         env:
           REGISTRY_IMAGE: ${{ needs.prepare.outputs.registry_image }}
           TAG1: ${{ needs.prepare.outputs.tag1 }}
-          TAG2: ${{ needs.prepare.outputs.tag2 }}
         run: |
           mapfile -t digests < <(
             find "$RUNNER_TEMP/container-digests" -maxdepth 1 -type f -printf '%f\n' | sort
@@ -250,11 +264,58 @@ jobs:
             exit 1
           fi
 
-          docker buildx imagetools create --tag "$TAG2" "${REGISTRY_IMAGE}@${manifest_digest}"
+          echo "manifest_digest=$manifest_digest" >> "$GITHUB_OUTPUT"
+          docker buildx imagetools inspect "${REGISTRY_IMAGE}@${manifest_digest}"
+
+  promote-moving:
+    if: github.event_name != 'pull_request'
+    needs: [prepare, publish-version]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    concurrency:
+      group: container-moving-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_version != '' && 'stable' || 'prerelease' }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote the moving tag from the verified digest
+        env:
+          MANIFEST_DIGEST: ${{ needs.publish-version.outputs.manifest_digest }}
+          REGISTRY_IMAGE: ${{ needs.prepare.outputs.registry_image }}
+          SOURCE_SHA: ${{ github.sha }}
+          TAG2: ${{ needs.prepare.outputs.tag2 }}
+        run: |
+          if [[ ! "$MANIFEST_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Unexpected manifest digest: $MANIFEST_DIGEST" >&2
+            exit 1
+          fi
+
+          current_sha=$(git rev-parse HEAD)
+          if [ "$current_sha" != "$SOURCE_SHA" ]; then
+            echo "::notice::Not updating $TAG2 because the default branch moved from $SOURCE_SHA to $current_sha"
+            exit 0
+          fi
+
+          manifest=$(docker buildx imagetools inspect "${REGISTRY_IMAGE}@${MANIFEST_DIGEST}" --raw)
+          docker buildx imagetools create --tag "$TAG2" "${REGISTRY_IMAGE}@${MANIFEST_DIGEST}"
           tag2_manifest=$(docker buildx imagetools inspect "$TAG2" --raw)
           if [ "$tag2_manifest" != "$manifest" ]; then
             echo "$TAG2 does not resolve to the validated manifest" >&2
             exit 1
           fi
 
-          docker buildx imagetools inspect "${REGISTRY_IMAGE}@${manifest_digest}"
+          docker buildx imagetools inspect "$TAG2"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -205,6 +205,24 @@ jobs:
             images+=("${REGISTRY_IMAGE}@sha256:${digest}")
           done
 
+          prospective_manifest=$(docker buildx imagetools create --dry-run "${images[@]}")
+          platforms=$(jq -c \
+            '[.manifests[]? | select((.platform.os // "unknown") != "unknown" or (.platform.architecture // "unknown") != "unknown") | "\(.platform.os)/\(.platform.architecture)"] | sort' \
+            <<< "$prospective_manifest")
+          if [ "$platforms" != '["linux/amd64","linux/arm64"]' ]; then
+            echo "Expected exactly linux/amd64 and linux/arm64, found $platforms" >&2
+            exit 1
+          fi
+
+          invalid_auxiliary=$(jq -c \
+            '[.manifests[]? | select((.platform.os // "unknown") == "unknown" and (.platform.architecture // "unknown") == "unknown") | select(.annotations["vnd.docker.reference.type"] != "attestation-manifest")]' \
+            <<< "$prospective_manifest")
+          if [ "$invalid_auxiliary" != '[]' ]; then
+            echo "Manifest contains unexpected auxiliary descriptors: $invalid_auxiliary" >&2
+            exit 1
+          fi
+
+          prospective_digest="sha256:$(printf '%s' "$prospective_manifest" | sha256sum | cut -d ' ' -f1)"
           docker buildx imagetools create \
             --tag "$TAG1" \
             --metadata-file "$RUNNER_TEMP/manifest-metadata.json" \
@@ -215,21 +233,14 @@ jobs:
             echo "Unexpected manifest digest: $manifest_digest" >&2
             exit 1
           fi
-
-          manifest=$(docker buildx imagetools inspect "${REGISTRY_IMAGE}@${manifest_digest}" --raw)
-          platforms=$(jq -c \
-            '[.manifests[]? | select((.platform.os // "unknown") != "unknown" or (.platform.architecture // "unknown") != "unknown") | "\(.platform.os)/\(.platform.architecture)"] | sort' \
-            <<< "$manifest")
-          if [ "$platforms" != '["linux/amd64","linux/arm64"]' ]; then
-            echo "Expected exactly linux/amd64 and linux/arm64, found $platforms" >&2
+          if [ "$manifest_digest" != "$prospective_digest" ]; then
+            echo "Published digest $manifest_digest differs from validated digest $prospective_digest" >&2
             exit 1
           fi
 
-          invalid_auxiliary=$(jq -c \
-            '[.manifests[]? | select((.platform.os // "unknown") == "unknown" and (.platform.architecture // "unknown") == "unknown") | select(.annotations["vnd.docker.reference.type"] != "attestation-manifest")]' \
-            <<< "$manifest")
-          if [ "$invalid_auxiliary" != '[]' ]; then
-            echo "Manifest contains unexpected auxiliary descriptors: $invalid_auxiliary" >&2
+          manifest=$(docker buildx imagetools inspect "${REGISTRY_IMAGE}@${manifest_digest}" --raw)
+          if [ "$manifest" != "$prospective_manifest" ]; then
+            echo "Published manifest differs from the validated dry-run manifest" >&2
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- build linux/amd64 and linux/arm64 on matching GitHub-hosted native runners
- publish architecture images by digest and update shared tags only after both builds succeed
- validate container workflow changes on pull requests without logging in or pushing
- cancel superseded runs so an older build cannot overwrite prerelease-latest

## Validation

- actionlint v1.7.7
- Ruby YAML parser
- git diff --check

The pull request workflow will perform native container builds for both architectures.