### PR TITLE
ci: 修复自动主线发布被静默跳过

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -92,6 +92,12 @@ jobs:
   build:
     name: Build checked artifacts
     needs: metadata
+    # The manual-only verifier is an indirect skipped ancestor on workflow_run.
+    # A status function is required here so GitHub does not inject success() and
+    # silently skip this job after metadata has explicitly accepted that path.
+    if: >-
+      !cancelled() &&
+      needs.metadata.result == 'success'
     uses: ./.github/workflows/build.yml
     permissions:
       contents: read
@@ -104,6 +110,10 @@ jobs:
   publish_version:
     name: Publish immutable prerelease
     needs: [metadata, build]
+    if: >-
+      !cancelled() &&
+      needs.metadata.result == 'success' &&
+      needs.build.result == 'success'
     permissions:
       contents: write
       packages: write
@@ -404,6 +414,10 @@ jobs:
   promote_moving:
     name: Promote prerelease-latest
     needs: [metadata, publish_version]
+    if: >-
+      !cancelled() &&
+      needs.metadata.result == 'success' &&
+      needs.publish_version.result == 'success'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## 问题

`Verify` 成功后的自动 `workflow_run` 路径会跳过手动专用的 `verify_manual_run`。虽然 `metadata` 用显式 `always()` 正常执行，后续 job 的默认 `success()` 仍会受到这个间接 skipped ancestor 影响，导致 build、publish 和 promotion 全部静默跳过，同时整条 workflow 被标记为 success。

失败证据：main run `33346056206` 只执行了 `Resolve verified source`，其余三个发布 job 均为 skipped。

## 修复

- `build` 使用 `!cancelled()` 状态函数覆盖隐式 `success()`，并只在直接依赖 `metadata` 成功时运行。
- `publish_version` 与 `promote_moving` 同样显式要求各自直接依赖成功，失败或取消仍然无法进入发布。
- 保留自动/手动来源校验、原生双架构构建、candidate runtime smoke、Registry/Git ref 锁和 moving alias 顺序。

## 验证

- Ruby YAML parse
- `git diff --check`
- actionlint 除其旧 schema 尚未识别的四处 GitHub 2026 `queue: max` 外无错误
- 预期以合并后的 main `workflow_run` 做端到端发布回归；只有完整 build/publish/promote 成功才视为修复完成