### PR TITLE
test: 修复主线 E2E 严格定位器失败

### DIFF
--- a/SecondDimensionWatcherReDive.Client/e2e/production-boundaries.spec.ts
+++ b/SecondDimensionWatcherReDive.Client/e2e/production-boundaries.spec.ts
@@ -162,7 +162,9 @@ test.describe("production boundary journeys", () => {
       page.getByRole("heading", { name: "Metadata review center" }),
     ).toBeVisible();
     await page.getByRole("tab", { name: /^Failed/ }).click();
-    await expect(page.getByText("Failed identifications")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Failed identifications" }),
+    ).toBeVisible();
 
     await page.goto("/incidents");
     await expect(


### PR DESCRIPTION
## 问题

PR #33 合并后的主线 Verify run 33348649005 中，metadata-review 旅程使用模糊的文本定位器；说明段落和二级标题都包含 Failed identifications，Playwright strict mode 因匹配两个元素而稳定失败，Quality gate 因此阻止发布。

## 修复

- 改用语义明确的 heading role + exact accessible name
- 保留生产 artifact E2E 的其余覆盖不变

## 验证

- Yarn 4.18 immutable install
- Prettier format check
- production Parcel build
- Playwright Chromium production-artifact journeys: 5/5 passed
- git diff --check
